### PR TITLE
[WIP] #12 Add Tasks to TaskGenerator

### DIFF
--- a/examples/vision/meta_mnist.py
+++ b/examples/vision/meta_mnist.py
@@ -66,7 +66,7 @@ def main(lr=0.005, maml_lr=0.01, iterations=1000, ways=5, shots=1, tps=32, fas=5
     mnist_train = l2l.data.MetaDataset(MNIST(download_location, train=True, download=True, transform=transformations))
     # mnist_test = MNIST(file_location, train=False, download=True, transform=transformations)
 
-    train_gen = l2l.data.TaskGenerator(mnist_train, ways=ways)
+    train_gen = l2l.data.TaskGenerator(mnist_train, ways=ways, tasks=10000)
     # test_gen = l2l.data.TaskGenerator(mnist_test, ways=ways)
 
     model = Net(ways)
@@ -81,8 +81,8 @@ def main(lr=0.005, maml_lr=0.01, iterations=1000, ways=5, shots=1, tps=32, fas=5
         iteration_acc = 0.0
         for _ in range(tps):
             learner = meta_model.clone()
-            train_task = train_gen.sample(shots=shots)
-            valid_task = train_gen.sample(shots=shots, classes=train_task.sampled_classes)
+            train_task = train_gen.sample()
+            valid_task = train_gen.sample(task=train_task.sampled_task)
 
             # Fast Adaptation
             for step in range(fas):

--- a/learn2learn/data/task_generator.py
+++ b/learn2learn/data/task_generator.py
@@ -193,7 +193,8 @@ class TaskGenerator:
         # sample from all the classes mentioned during the initialization of the TaskGenerator
         if task is None:
             # select few classes that will be selected for this task (for eg, 6,4,7 from 0-9 in MNIST when ways are 3)
-            task_to_sample = np.random.choice(self.tasks, size=1)
+            rand_idx = random.randint(0, len(self.tasks))
+            task_to_sample = self.tasks[rand_idx]
         else:
             task_to_sample = task
             assert self._check_task(task_to_sample), ValueError("Task is malformed.")

--- a/learn2learn/data/task_generator.py
+++ b/learn2learn/data/task_generator.py
@@ -178,6 +178,7 @@ class TaskGenerator:
             task_to_sample = np.random.choice(self.tasks, size=1)
         else:
             task_to_sample = task
+            assert self._check_task(task_to_sample), ValueError("Task is malformed.")
 
         # encode labels (map 6,4,7 to 0,1,2 so that we can do a BCELoss)
         label_encoder = LabelEncoder(task_to_sample)

--- a/learn2learn/data/task_generator.py
+++ b/learn2learn/data/task_generator.py
@@ -143,7 +143,21 @@ class TaskGenerator:
 
         return [get_samples() for _ in range(n)]
 
+    def __iter__(self):
+        self.tasks_idx = 0
+        return self
+
+    def __len__(self):
+        return len(self.tasks)
+
     def __next__(self):
+        """
+        TODO : Add the following test case
+        for i, task in enumerate(tg):
+            assert task.sampled_task == tg.tasks[i]
+        Returns:
+
+        """
         try:
             task = self.sample(self.tasks[self.tasks_idx])
         except IndexError:
@@ -160,8 +174,7 @@ class TaskGenerator:
 
         Args:
             shots: number of data points to return per class, if none then gets the (default : None)
-            classes: Optional list,
-            labels_to_sample: List of labels you want to sample from
+            task: List of labels you want to sample from
 
         Returns: Dataset, list(labels)
 

--- a/learn2learn/data/task_generator.py
+++ b/learn2learn/data/task_generator.py
@@ -75,7 +75,7 @@ class LabelEncoder:
 
 
 class TaskGenerator:
-    def __init__(self, dataset: MetaDataset, classes: list = None, ways: int = 3):
+    def __init__(self, dataset: MetaDataset, classes: list = None, ways: int = 3, tasks: list = 10):
         """
 
         Args:

--- a/learn2learn/data/task_generator.py
+++ b/learn2learn/data/task_generator.py
@@ -1,4 +1,6 @@
+import random
 from collections import defaultdict
+from typing import Optional, List, Union
 
 import numpy as np
 from torch.utils.data import Dataset
@@ -9,10 +11,10 @@ class SampleDataset(Dataset):
     SampleDataset to be used by TaskGenerator
     """
 
-    def __init__(self, data, labels, sampled_classes):
+    def __init__(self, data, labels, sampled_task):
         self.data = data
         self.label = labels
-        self.sampled_classes = sampled_classes
+        self.sampled_task = sampled_task
 
     def __len__(self):
         return len(self.data)
@@ -75,13 +77,27 @@ class LabelEncoder:
 
 
 class TaskGenerator:
-    def __init__(self, dataset: MetaDataset, classes: list = None, ways: int = 3, tasks: list = 10):
+    def __init__(self, dataset: MetaDataset,
+                 classes: Optional[list] = None,
+                 ways: int = 3,
+                 shots: Optional[int] = 1,
+                 tasks: Union[List[int], int] = 10):
         """
 
         Args:
-            dataset: should be a MetaDataset
-            classes: List of classes to sample from
-            ways: number of labels to sample from
+            dataset: should be a MetaDataset.
+            classes: List of classes to sample from, if none then sample from all available classes in dataset.
+                    (default: None)
+            ways: number of labels to sample from (default: 3)
+            shots: number of data points per task to sample (default: 1)
+            task: if specified as an int, a list of of size task would be generated from which we'll sample.
+                    if specified as a list, then that list of tasks would be used to sample always.
+
+                    The acceptable shape of list would be `n * w`
+                    n : the number of tasks to sample
+                    w : the number of ways
+
+                    Each of the task should have w distinct elements all of which are required to be a subset of ways.
         """
 
         # TODO : Add conditional check to work even when dataset isn't MetaDataset and a torch.Dataset
@@ -89,44 +105,86 @@ class TaskGenerator:
         self.dataset = dataset
         self.ways = ways
         self.classes = classes
+        self.shots = shots
+
         if classes is None:
             self.classes = self.dataset.labels
 
+        if isinstance(tasks, int):
+            self.tasks = self.generate_n_tasks(tasks)
+        elif isinstance(tasks, list):
+            self.tasks = tasks
+        else:
+            raise TypeError(f"tasks is not either of int/list but rather {type(tasks)}")
+
+        # used for next(taskgenerator)
+        self.tasks_idx = 0
+
         assert len(self.classes) >= ways, ValueError("Ways are more than the number of classes available")
         self._check_classes(self.classes)
+        self._check_tasks(self.tasks)
 
-    def sample(self, classes: list = None, shots: int = 1):
+        # TODO : assert that shots are always less than equal to min_samples for each class
+
+    def generate_n_tasks(self, n):
+        """
+
+        Args:
+            n: Number of tasks to generate
+
+        Returns: A list of shape `n * w` where n is the number of tasks to generate and w is the ways.
+
+        """
+        random.shuffle(self.classes)
+        return [self.classes[:self.ways] for _ in range(n)]
+
+    def __next__(self):
+        try:
+            task = self.sample(self.tasks[self.tasks_idx])
+        except IndexError:
+            raise StopIteration()
+
+        self.tasks_idx += 1
+        return task
+
+    def sample(self, task: list = None, shots: Optional[int] = None):
         """ Returns a dataset and the labels that we have sampled.
 
         The dataset is of length `shots * ways`.
         The length of labels we have sampled is the same as `shots`.
 
         Args:
-            shots: sample size
+            shots: number of data points to return per class, if none then gets the (default : None)
             classes: Optional list,
             labels_to_sample: List of labels you want to sample from
 
         Returns: Dataset, list(labels)
 
+        Raises:
+            ValueError : when shots is undefined both in class definition and method
+
         """
+        # If shots isn't defined, then try to inherit from object
+        if shots is None:
+            if self.shots is None:
+                raise ValueError(
+                    "Shots is undefined in object definition neither while calling the sample method.")
+            shots = self.shots
 
         # If classes aren't specified while calling the function, then we can
         # sample from all the classes mentioned during the initialization of the TaskGenerator
-        if classes is None:
-            # assure that self.classes is a subset of self.dataset.labels
-            self._check_classes(self.classes)
-
+        if task is None:
             # select few classes that will be selected for this task (for eg, 6,4,7 from 0-9 in MNIST when ways are 3)
-            classes_to_sample = np.random.choice(self.classes, size=self.ways, replace=False)
+            task_to_sample = np.random.choice(self.tasks, size=1)
         else:
-            classes_to_sample = classes
+            task_to_sample = task
 
         # encode labels (map 6,4,7 to 0,1,2 so that we can do a BCELoss)
-        label_encoder = LabelEncoder(classes_to_sample)
+        label_encoder = LabelEncoder(task_to_sample)
 
         data_indices = []
         data_labels = []
-        for _class in classes_to_sample:
+        for _class in task_to_sample:
             # select subset of indices from each of the classes and add it to data_indices
             data_indices.extend(np.random.choice(self.dataset.labels_to_indices[_class], shots, replace=False))
             # add those labels to data_labels (6 mapped to 0, so add 0's initially then 1's (for 4) and so on)
@@ -134,7 +192,16 @@ class TaskGenerator:
 
         # map data indices to actual data
         data = [self.dataset[idx][0] for idx in data_indices]
-        return SampleDataset(data, data_labels, classes_to_sample)
+        return SampleDataset(data, data_labels, task_to_sample)
 
     def _check_classes(self, classes):
         assert len(set(classes) - set(self.dataset.labels)) == 0, "classes contains a label that isn't in dataset"
+
+    def _check_task(self, task):
+        # check if each individual task is a subset of self.classes and has no duplicates
+        return (set(task) - set(self.classes) == 0) and (len(set(task)) - len(task) == 0)
+
+    def _check_tasks(self, tasks):
+        # ensure that all tasks are correctly defined.
+        assert len(list(filter(self._check_task, tasks))) - len(
+            tasks) == 0, "Some task in mentioned tasks contain extra variables"

--- a/learn2learn/data/task_generator.py
+++ b/learn2learn/data/task_generator.py
@@ -77,7 +77,8 @@ class LabelEncoder:
 
 
 class TaskGenerator:
-    def __init__(self, dataset: MetaDataset,
+    def __init__(self,
+                 dataset: MetaDataset,
                  classes: Optional[list] = None,
                  ways: int = 3,
                  shots: Optional[int] = 1,


### PR DESCRIPTION
The API would change from current
```python
tg = TaskGenerator(dataset, classes = [0,1,2,3], ways = 3)
tg.sample(shots=1)
tg.sample( classes=[1,2,3])

```

to 

```python
tg = TaskGenerator(dataset, classes = [0,1,2,3], ways = 3, shots=1, tasks = [[1,2,3], [0,1,2]...)
#                 OR
tg = TaskGenerator(dataset, classes = [0,1,2,3], ways = 3, shots=1, tasks = 100)
tg.sample() # this function earlier required shots to be defined, now it can be defined durining init of the TG object
tg.sample(task=[1,2,3])
next(tg) # this function wasn't earlier defined
```
