### PR TITLE
Fix Omniglot memory leak.

### DIFF
--- a/examples/vision/maml_omniglot.py
+++ b/examples/vision/maml_omniglot.py
@@ -10,8 +10,6 @@ from torch import nn
 from torch import optim
 from torchvision import transforms
 
-from copy import deepcopy
-
 import learn2learn as l2l
 
 
@@ -114,7 +112,7 @@ def main(
             meta_train_accuracy += evaluation_accuracy.item()
 
             # Compute meta-validation loss
-            learner = deepcopy(maml)
+            learner = maml.clone()
             adaptation_data = valid_generator.sample(shots=shots)
             evaluation_data = valid_generator.sample(shots=shots,
                                                      task=adaptation_data.sampled_task)
@@ -128,7 +126,7 @@ def main(
             meta_valid_accuracy += evaluation_accuracy.item()
 
             # Compute meta-testing loss
-            learner = deepcopy(maml)
+            learner = maml.clone()
             adaptation_data = test_generator.sample(shots=shots)
             evaluation_data = test_generator.sample(shots=shots,
                                                     task=adaptation_data.sampled_task)

--- a/tests/integration/maml_omniglot_test.py
+++ b/tests/integration/maml_omniglot_test.py
@@ -10,7 +10,6 @@ from torchvision import transforms
 
 import learn2learn as l2l
 
-from copy import deepcopy
 from PIL.Image import LANCZOS
 
 
@@ -112,7 +111,7 @@ def main(
             meta_train_accuracy += evaluation_accuracy.item()
 
             # Compute meta-validation loss
-            learner = deepcopy(maml)
+            learner = maml.clone()
             adaptation_data = valid_generator.sample(shots=shots)
             evaluation_data = valid_generator.sample(shots=shots,
                                                      task=adaptation_data.sampled_task)
@@ -126,7 +125,7 @@ def main(
             meta_valid_accuracy += evaluation_accuracy.item()
 
             # Compute meta-testing loss
-            learner = deepcopy(maml)
+            learner = maml.clone()
             adaptation_data = test_generator.sample(shots=shots)
             evaluation_data = test_generator.sample(shots=shots,
                                                     task=adaptation_data.sampled_task)


### PR DESCRIPTION
### Description

Fixes #88 

Swaps `deepcopy(maml)` by `maml.clone()` for validation and testing  tasks in the Omniglot example and unit test.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [ ] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [ ] My modifications are documented.

#### Optional

If you make major changes to the core library, please copy-paste the output of running `make alltests` below.

~~~shell
OMP_NUM_THREADS=1 \
MKL_NUM_THREADS=1 \
python -W ignore -m unittest discover -s 'tests' -p '*_test.py' -v
test_final_accuracy (integration.maml_omniglot_test.MAMLOmniglotIntegrationTests) ... Downloading https://github.com/brendenlake/omniglot/raw/master/python/images_background.zip to ./data/omniglot-py/images_background.zip
9469952it [00:01, 7913811.97it/s]                                                                                                                                                                                       
Extracting downloaded file: ./data/omniglot-py/images_background.zip
Downloading https://github.com/brendenlake/omniglot/raw/master/python/images_evaluation.zip to ./data/omniglot-py/images_evaluation.zip
6463488it [00:01, 5833504.09it/s]                                                                                                                                                                                       
Extracting downloaded file: ./data/omniglot-py/images_evaluation.zip
ok
test_final_accuracy (integration.meta_mnist_test.MNISTIntegrationTests) ... Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to /tmp/datasets/MNIST/raw/train-images-idx3-ubyte.gz
9920512it [00:01, 9092392.52it/s]                                                                                                                                                                                       
Extracting /tmp/datasets/MNIST/raw/train-images-idx3-ubyte.gz
Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz to /tmp/datasets/MNIST/raw/train-labels-idx1-ubyte.gz
32768it [00:00, 108287.69it/s]                                                                                                                                                                                          
Extracting /tmp/datasets/MNIST/raw/train-labels-idx1-ubyte.gz
Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz to /tmp/datasets/MNIST/raw/t10k-images-idx3-ubyte.gz
1654784it [00:00, 402513.85it/s]                                                                                                                                                                                        
Extracting /tmp/datasets/MNIST/raw/t10k-images-idx3-ubyte.gz
Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz to /tmp/datasets/MNIST/raw/t10k-labels-idx1-ubyte.gz
8192it [00:00, 58636.07it/s]                                                                                                                                                                                            
Extracting /tmp/datasets/MNIST/raw/t10k-labels-idx1-ubyte.gz
Processing...
Done!
ok 
test_adaptation (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_clone_module (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_graph_connection (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_adaptation (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_clone_module (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_graph_connection (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_meta_lr (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
Downloading https://github.com/brendenlake/omniglot/raw/master/python/images_background.zip to /tmp/datasets/omniglot-py/images_background.zip
9469952it [00:01, 5757985.65it/s]                                                                                                                                                                                       
Extracting downloaded file: /tmp/datasets/omniglot-py/images_background.zip
Downloading https://github.com/brendenlake/omniglot/raw/master/python/images_evaluation.zip to /tmp/datasets/omniglot-py/images_evaluation.zip
6463488it [00:00, 8779756.49it/s]                                                                                                                                                                                       
Extracting downloaded file: /tmp/datasets/omniglot-py/images_evaluation.zip
test_data_labels_length (unit.task_generator.metadataset_test.TestMetaDataset) ... ok
test_data_labels_values (unit.task_generator.metadataset_test.TestMetaDataset) ... ok
test_data_length (unit.task_generator.metadataset_test.TestMetaDataset) ... ok
test_fails_with_non_torch_dataset (unit.task_generator.metadataset_test.TestMetaDataset) ... ok
test_get_dict_of_labels_to_indices (unit.task_generator.metadataset_test.TestMetaDataset) ... ok
test_get_item (unit.task_generator.metadataset_test.TestMetaDataset) ... ok
test_does_not_fail_with_torch_dataset (unit.task_generator.task_generator_test.TestTaskGenerator) ... ok
test_next_tg (unit.task_generator.task_generator_test.TestTaskGenerator) ... ok
test_tasks_dont_change (unit.task_generator.task_generator_test.TestTaskGenerator) ... ok
test_tg_fails_with_np_array (unit.task_generator.task_generator_test.TestTaskGenerator) ... ok
test_tg_with_int_task (unit.task_generator.task_generator_test.TestTaskGenerator) ... ok
test_tg_with_list_task (unit.task_generator.task_generator_test.TestTaskGenerator) ... ok
test_tg_with_none_task (unit.task_generator.task_generator_test.TestTaskGenerator)
In this test we want to ensure that we sample from all possible tasks i.e 20 given 1000 iterations. ... ok
test_distribution_clone (unit.utils_test.UtilTests) ... ok
test_distribution_detach (unit.utils_test.UtilTests) ... ok
test_module_clone (unit.utils_test.UtilTests) ... ok
test_module_detach (unit.utils_test.UtilTests) ... ok
test_download (unit.vision.cifarfs_test.CIFARFSTests) ... Downloading CIFARFS to  ./data
Creating CIFARFS splits
ok

----------------------------------------------------------------------
Ran 27 tests in 231.198s

OK
make lint
make[1]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
pycodestyle learn2learn/ --max-line-length=160
make[1]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
OMP_NUM_THREADS=1 \
MKL_NUM_THREADS=1 \
python -W ignore -m unittest discover -s 'tests' -p '*_test_notravis.py' -v
test_final_accuracy (integration.maml_miniimagenet_test_notravis.MAMLMiniImagenetIntegrationTests) ... Downloading: ./data/mini-imagene
OK
make lint
make[1]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
pycodestyle learn2learn/ --max-line-length=160
make[1]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
OMP_NUM_THREADS=1 \
MKL_NUM_THREADS=1 \
python -W ignore -m unittest discover -s 'tests' -p '*_test_notravis.py' -v
test_final_accuracy (integration.maml_miniimagenet_test_notravis.MAMLMiniImagenetIntegrationTests) ... Downloading: ./data/mini-imagenet-cache-train.pkl
Download finished
Downloading: ./data/mini-imagenet-cache-validation.pkl
Download finished
Downloading: ./data/mini-imagenet-cache-test.pkl
Download finishedt-cache-train.pkl
Download finished
Downloading: ./data/mini-imagenet-cache-validation.pkl
Download finished
Downloading: ./data/mini-imagenet-cache-test.pkl
Download finished


Iteration 0
Meta Train Error 0.06646006065420806
Meta Train Accuracy 0.2049999984446913
Meta Valid Error 0.06742011185269803
Meta Valid Accuracy 0.21124999970197678
Meta Test Error 0.06593708402942866
Meta Test Accuracy 0.2512499999720603
ok

----------------------------------------------------------------------
Ran 1 test in 157.756s

OK
~~~
