### PR TITLE
Fix path bug & improved consistency across dataset files

### DIFF
--- a/learn2learn/vision/datasets/cifarfs.py
+++ b/learn2learn/vision/datasets/cifarfs.py
@@ -47,9 +47,9 @@ class CIFARFS(ImageFolder):
     """
 
     def __init__(self, root, mode='train', transform=None, target_transform=None):
-        self.root = root
-        if not os.path.exists(root):
-            os.mkdir(root)
+        self.root = os.path.expanduser(root)
+        if not os.path.exists(self.root):
+            os.mkdir(self.root)
         self.transform = transform
         self.target_transform = target_transform
         self.mode = mode

--- a/learn2learn/vision/datasets/fc100.py
+++ b/learn2learn/vision/datasets/fc100.py
@@ -52,9 +52,9 @@ class FC100(data.Dataset):
 
     def __init__(self, root, mode='train', transform=None, target_transform=None):
         super(FC100, self).__init__()
-        self.root = root
-        if not os.path.exists(root):
-            os.mkdir(root)
+        self.root = os.path.expanduser(root)
+        if not os.path.exists(self.root):
+            os.mkdir(self.root)
         self.transform = transform
         self.target_transform = target_transform
         if mode not in ['train', 'validation', 'test']:
@@ -102,9 +102,9 @@ class FC100(data.Dataset):
 
 
 if __name__ == '__main__':
-    dataset = FC100(root=os.path.expanduser('~/data'))
+    dataset = FC100(root='~/data')
     img, tgt = dataset[43]
-    dataset = FC100(root=os.path.expanduser('~/data'), mode='validation')
+    dataset = FC100(root='~/data', mode='validation')
     img, tgt = dataset[43]
-    dataset = FC100(root=os.path.expanduser('~/data'), mode='test')
+    dataset = FC100(root='~/data', mode='test')
     img, tgt = dataset[43]

--- a/learn2learn/vision/datasets/fc100.py
+++ b/learn2learn/vision/datasets/fc100.py
@@ -64,7 +64,7 @@ class FC100(data.Dataset):
         google_drive_file_id = '1_ZsLyqI487NRDQhwvI7rg86FK3YAZvz1'
 
         if not self._check_exists():
-            self.download(google_drive_file_id, self.root)
+            self.download(google_drive_file_id)
 
         short_mode = 'val' if mode == 'validation' else mode
         fc100_path = os.path.join(self.root, 'FC100_' + short_mode + '.pickle')
@@ -75,12 +75,12 @@ class FC100(data.Dataset):
         self.images = archive['data']
         self.labels = archive['labels']
 
-    def download(self, file_id, destination):
-        archive_path = os.path.join(destination, 'fc100.zip')
+    def download(self, file_id):
+        archive_path = os.path.join(self.root, 'fc100.zip')
         print('Downloading FC100. (160Mb) Please be patient.')
         download_file_from_google_drive(file_id, archive_path)
         archive_file = zipfile.ZipFile(archive_path)
-        archive_file.extractall(destination)
+        archive_file.extractall(self.root)
         os.remove(archive_path)
 
     def __getitem__(self, idx):

--- a/learn2learn/vision/datasets/fgvc_aircraft.py
+++ b/learn2learn/vision/datasets/fgvc_aircraft.py
@@ -105,7 +105,7 @@ class FGVCAircraft(Dataset):
         self._bookkeeping_path = os.path.join(self.root, 'fgvc-aircraft-' + mode + '-bookkeeping.pkl')
 
         if not self._check_exists() and download:
-            self.download(self.root)
+            self.download()
 
         self.load_data(mode)
 
@@ -117,10 +117,10 @@ class FGVCAircraft(Dataset):
             os.path.exists(images_path) and \
             os.path.exists(labels_path)
 
-    def download(self, root):
-        if not os.path.exists(root):
-            os.mkdir(root)
-        data_path = os.path.join(root, DATASET_DIR)
+    def download(self):
+        if not os.path.exists(self.root):
+            os.mkdir(self.root)
+        data_path = os.path.join(self.root, DATASET_DIR)
         if not os.path.exists(data_path):
             os.mkdir(data_path)
         tar_path = os.path.join(data_path, os.path.basename(DATASET_URL))

--- a/learn2learn/vision/datasets/full_omniglot.py
+++ b/learn2learn/vision/datasets/full_omniglot.py
@@ -48,7 +48,7 @@ class FullOmniglot(Dataset):
     """
 
     def __init__(self, root, transform=None, target_transform=None, download=False):
-        self.root = root
+        self.root = os.path.expanduser(root)
         self.transform = transform
         self.target_transform = target_transform
 

--- a/learn2learn/vision/datasets/full_omniglot.py
+++ b/learn2learn/vision/datasets/full_omniglot.py
@@ -53,10 +53,10 @@ class FullOmniglot(Dataset):
         self.target_transform = target_transform
 
         # Set up both the background and eval dataset
-        omni_background = Omniglot(root, background=True, download=download)
+        omni_background = Omniglot(self.root, background=True, download=download)
         # Eval labels also start from 0.
         # It's important to add 964 to label values in eval so they don't overwrite background dataset.
-        omni_evaluation = Omniglot(root,
+        omni_evaluation = Omniglot(self.root,
                                    background=False,
                                    download=download,
                                    target_transform=lambda x: x + len(omni_background._characters))

--- a/learn2learn/vision/datasets/mini_imagenet.py
+++ b/learn2learn/vision/datasets/mini_imagenet.py
@@ -70,9 +70,9 @@ class MiniImagenet(data.Dataset):
 
     def __init__(self, root, mode='train', transform=None, target_transform=None):
         super(MiniImagenet, self).__init__()
-        self.root = root
-        if not os.path.exists(root):
-            os.mkdir(root)
+        self.root = os.path.expanduser(root)
+        if not os.path.exists(self.root):
+            os.mkdir(self.root)
         self.transform = transform
         self.target_transform = target_transform
         self.mode = mode

--- a/learn2learn/vision/datasets/mini_imagenet.py
+++ b/learn2learn/vision/datasets/mini_imagenet.py
@@ -87,7 +87,7 @@ class MiniImagenet(data.Dataset):
             raise ('ValueError', 'Needs to be train, test or validation')
 
         if not self._check_exists():
-            download_pkl(google_drive_file_id, root, mode)
+            download_pkl(google_drive_file_id, self.root, mode)
 
         pickle_file = os.path.join(self.root, 'mini-imagenet-cache-' + mode + '.pkl')
         with open(pickle_file, 'rb') as f:

--- a/learn2learn/vision/datasets/tiered_imagenet.py
+++ b/learn2learn/vision/datasets/tiered_imagenet.py
@@ -54,9 +54,9 @@ class TieredImagenet(data.Dataset):
 
     def __init__(self, root, mode='train', transform=None, target_transform=None, download=False):
         super(TieredImagenet, self).__init__()
-        self.root = root
-        if not os.path.exists(root):
-            os.mkdir(root)
+        self.root = os.path.expanduser(root)
+        if not os.path.exists(self.root):
+            os.mkdir(self.root)
         self.transform = transform
         self.target_transform = target_transform
         if mode not in ['train', 'validation', 'test']:
@@ -105,9 +105,9 @@ class TieredImagenet(data.Dataset):
 
 
 if __name__ == '__main__':
-    dataset = TieredImagenet(root=os.path.expanduser('~/data'))
+    dataset = TieredImagenet(root='~/data')
     img, tgt = dataset[43]
-    dataset = TieredImagenet(root=os.path.expanduser('~/data'), mode='validation')
+    dataset = TieredImagenet(root='~/data', mode='validation')
     img, tgt = dataset[43]
-    dataset = TieredImagenet(root=os.path.expanduser('~/data'), mode='test')
+    dataset = TieredImagenet(root='~/data', mode='test')
     img, tgt = dataset[43]

--- a/learn2learn/vision/datasets/vgg_flowers.py
+++ b/learn2learn/vision/datasets/vgg_flowers.py
@@ -71,7 +71,7 @@ class VGGFlower102(Dataset):
         self._bookkeeping_path = os.path.join(self.root, 'vgg-flower102-' + mode + '-bookkeeping.pkl')
 
         if not self._check_exists() and download:
-            self.download(self.root)
+            self.download()
 
         self.load_data(mode)
 
@@ -79,10 +79,10 @@ class VGGFlower102(Dataset):
         data_path = os.path.join(self.root, DATA_DIR)
         return os.path.exists(data_path)
 
-    def download(self, root):
-        if not os.path.exists(root):
-            os.mkdir(root)
-        data_path = os.path.join(root, DATA_DIR)
+    def download(self):
+        if not os.path.exists(self.root):
+            os.mkdir(self.root)
+        data_path = os.path.join(self.root, DATA_DIR)
         if not os.path.exists(data_path):
             os.mkdir(data_path)
         tar_path = os.path.join(data_path, os.path.basename(IMAGES_URL))


### PR DESCRIPTION
### Fix path bug & slightly improve consistency in dataset files.

**Bug:** When trying to run some of the vision examples, it would return the following error:

`FileNotFoundError: [Errno 2] No such file or directory: '~/data'`

This is because the string '~/data' was not being converted to the actual path (using `os.path.expanduser`).

**Fix:** All dataset files now turn their path argument into the full path using os.path.expanduser.

**Consistency:** Some of the datasets were already using _os.path.expanduser_ when initialized. Some were expecting the argument would be already pre-processed before initialized. Now all the datasets expect the path in the form of "~/data" or "./data" and convert the variable during initialization. Also some of the datasets were passing the path `root` as argument to a function within the same class when they could just use the `self.root`, this has also been addressed for better clarity.

## This is a modification to the core library but has not been tested due to #111 

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [ ] My modifications are tested.
- [x] My modifications are documented.

#### Optional

If you make major changes to the core library, please run `make alltests` and copy-paste the content of `alltests.txt` below.

~~~shell
[PASTE HERE]
~~~