### PR TITLE
Fix Cython compilation when installing from sources.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 global-include *.pyx
 global-include *.pxd
+include learn2learn/**/*

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ clean:
 	rm -f learn2learn/**/*.c
 	rm -f learn2learn/**/*.so
 	rm -f learn2learn/**/*.html
+	rm -f learn2learn.egg-info/**/*.html
 
 # Admin
 dev:

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ install(
     packages=find_packages(),
     ext_modules=cythonize(extensions, compiler_directives=compiler_directives),
     cmdclass={'build_ext': build_ext},
+    zip_safe=False,  # as per Cython docs
     version=VERSION,
     description='PyTorch Meta-Learning Framework for Researchers',
     long_description=open('README.md').read(),


### PR DESCRIPTION
### Description

Fixes #111 

This PR fixes the installation issue when running `python setup.py install` on a cloned repo.

The changes are to include all files `learn2learn/` so that the `.so` files are copied over. Moreover, I also added `zip_safe=False` to the setuptools command, as recommended on the Cython documentation page.

References:

* https://stackoverflow.com/a/32537661
* https://cython.readthedocs.io/en/latest/src/quickstart/build.html#building-a-cython-module-using-distutils

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [ ] My contribution modifies code in the main library.
- [ ] My modifications are tested.
- [ ] My modifications are documented.
