### PR TITLE
Move task initialization to transforms.

### DIFF
--- a/examples/vision/maml_omniglot.py
+++ b/examples/vision/maml_omniglot.py
@@ -74,9 +74,10 @@ def main(
     random.shuffle(classes)
 
     train_transforms = [
-        l2l.data.transforms.FilterLabels(dataset, classes[:1100]),
-        l2l.data.transforms.NWays(dataset, ways),
-        l2l.data.transforms.KShots(dataset, 2*shots),
+        l2l.data.transforms.FusedNWaysKShots(dataset,
+                                             n=ways,
+                                             k=2*shots,
+                                             filter_labels=classes[:1100]),
         l2l.data.transforms.LoadData(dataset),
         l2l.data.transforms.RemapLabels(dataset),
         l2l.data.transforms.ConsecutiveLabels(dataset),
@@ -87,9 +88,10 @@ def main(
                                        num_tasks=20000)
 
     valid_transforms = [
-        l2l.data.transforms.FilterLabels(dataset, classes[1100:1200]),
-        l2l.data.transforms.NWays(dataset, ways),
-        l2l.data.transforms.KShots(dataset, 2*shots),
+        l2l.data.transforms.FusedNWaysKShots(dataset,
+                                             n=ways,
+                                             k=2*shots,
+                                             filter_labels=classes[1100:1200]),
         l2l.data.transforms.LoadData(dataset),
         l2l.data.transforms.RemapLabels(dataset),
         l2l.data.transforms.ConsecutiveLabels(dataset),
@@ -100,9 +102,10 @@ def main(
                                        num_tasks=1024)
 
     test_transforms = [
-        l2l.data.transforms.FilterLabels(dataset, classes[1200:]),
-        l2l.data.transforms.NWays(dataset, ways),
-        l2l.data.transforms.KShots(dataset, 2*shots),
+        l2l.data.transforms.FusedNWaysKShots(dataset,
+                                             n=ways,
+                                             k=2*shots,
+                                             filter_labels=classes[1200:]),
         l2l.data.transforms.LoadData(dataset),
         l2l.data.transforms.RemapLabels(dataset),
         l2l.data.transforms.ConsecutiveLabels(dataset),

--- a/learn2learn/data/task_dataset.pxd
+++ b/learn2learn/data/task_dataset.pxd
@@ -1,5 +1,3 @@
-# cython: embedsignature=True
-# cython: profile=True
 # cython: language_version=3
 
 

--- a/learn2learn/data/task_dataset.pyx
+++ b/learn2learn/data/task_dataset.pyx
@@ -15,6 +15,19 @@ from torch.utils.data._utils import collate
 import learn2learn as l2l
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.initializedcheck(False)
+@cython.nonecheck(False)
+@cython.infer_types(False)
+cdef list fast_allocate(long n):
+    cdef list result = [None] * n
+    cdef long i
+    for i in range(n):
+        result[i] = DataDescription(i)
+    return result
+
+
 cdef class DataDescription:
 
     """
@@ -32,19 +45,6 @@ cdef class DataDescription:
     def __init__(self, long index):
         self.index = index
         self.transforms = []
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.initializedcheck(False)
-@cython.nonecheck(False)
-@cython.infer_types(False)
-cdef list fast_allocate(long n):
-    cdef list result = [None] * n
-    cdef long i
-    for i in range(n):
-        result[i] = DataDescription(i)
-    return result
 
 
 cdef class TaskDataset(object):
@@ -114,8 +114,8 @@ cdef class TaskDataset(object):
 
     cpdef sample_task_description(self):
         #  Samples a new task description.
-        # cdef list description = [DataDescription(i) for i in range(len(self.dataset))]
-        cdef list description = fast_allocate(len(self.dataset))
+        # cdef list description = fast_allocate(len(self.dataset))
+        description = None
         if callable(self.task_transforms):
             return self.task_transforms(description)
         for transform in self.task_transforms:

--- a/learn2learn/data/transforms.pyx
+++ b/learn2learn/data/transforms.pyx
@@ -30,7 +30,7 @@ Then, all samples are collated via the `TaskDataset`'s collate function.
 """
 
 cimport cython
-from cpython cimport array
+from cpython cimport array, bool
 
 import cython
 import copy
@@ -43,7 +43,29 @@ from .task_dataset cimport DataDescription
 from .task_dataset import DataDescription
 
 
-class LoadData(object):
+cdef class TaskTransform:
+
+    cdef public:
+        object dataset
+
+    def __init__(self, dataset):
+        self.dataset = dataset
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.initializedcheck(False)
+    @cython.nonecheck(False)
+    @cython.infer_types(False)
+    cpdef new_task(self):
+        cdef long n = len(self.dataset)
+        cdef list task_description = [None] * n
+        cdef long i
+        for i in range(n):
+            task_description[i] = DataDescription(i)
+        return task_description
+
+
+class LoadData(TaskTransform):
 
     """
     [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/data/transforms.py)
@@ -59,15 +81,18 @@ class LoadData(object):
     """
 
     def __init__(self, dataset):
+        super(LoadData, self).__init__(dataset)
         self.dataset = dataset
 
     def __call__(self, task_description):
+        if task_description is None:
+            task_description = self.new_task()
         for data_description in task_description:
             data_description.transforms.append(lambda x: self.dataset[x])
         return task_description
 
 
-cdef class FilterLabels(object):
+cdef class FilterLabels(TaskTransform):
 
     """
     [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/data/transforms.py)
@@ -90,6 +115,7 @@ cdef class FilterLabels(object):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     def __init__(self, dataset, list labels):
+        super(FilterLabels, self).__init__(dataset)
         cdef dict indices_to_labels = <dict>dataset.indices_to_labels
         cdef long len_dataset = len(dataset)
         cdef long i
@@ -99,6 +125,8 @@ cdef class FilterLabels(object):
             self.filtered_indices[i] = int(indices_to_labels[i] in self.labels)
 
     def __call__(self, list task_description):
+        if task_description is None:
+            task_description = self.new_task()
         cdef DataDescription dd
         cdef list result = []
         for dd in task_description:
@@ -107,7 +135,7 @@ cdef class FilterLabels(object):
         return result
 
 
-class ConsecutiveLabels(object):
+class ConsecutiveLabels(TaskTransform):
 
     """
     [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/data/transforms.py)
@@ -127,16 +155,19 @@ class ConsecutiveLabels(object):
     """
 
     def __init__(self, dataset):
+        super(ConsecutiveLabels, self).__init__(dataset)
         self.dataset = dataset
 
     def __call__(self, task_description):
+        if task_description is None:
+            task_description = self.new_task()
         pairs = [(dd, self.dataset.indices_to_labels[dd.index])
                  for dd in task_description]
         pairs = sorted(pairs, key=lambda x: x[1])
         return [p[0] for p in pairs]
 
 
-class RemapLabels(object):
+class RemapLabels(TaskTransform):
 
     """
     [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/data/transforms.py)
@@ -152,6 +183,7 @@ class RemapLabels(object):
     """
 
     def __init__(self, dataset, shuffle=True):
+        super(RemapLabels, self).__init__(dataset)
         self.dataset = dataset
         self.shuffle = shuffle
 
@@ -161,6 +193,8 @@ class RemapLabels(object):
         return data
 
     def __call__(self, task_description):
+        if task_description is None:
+            task_description = self.new_task()
         labels = list(set(self.dataset.indices_to_labels[dd.index] for dd in task_description))
         if self.shuffle:
             random.shuffle(labels)
@@ -174,7 +208,7 @@ class RemapLabels(object):
         return task_description
 
 
-cdef class NWays(object):
+cdef class NWays(TaskTransform):
 
     """
     [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/data/transforms.py)
@@ -196,10 +230,25 @@ cdef class NWays(object):
         dict indices_to_labels
 
     def __init__(self, dataset, n=2):
+        super(NWays, self).__init__(dataset)
         self.n = n
         self.indices_to_labels = <dict>dataset.indices_to_labels
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cpdef new_task(self):  # Efficient initializer
+        cdef list labels = self.dataset.labels
+        cdef list task_description = []
+        cdef dict labels_to_indices = <dict>self.dataset.labels_to_indices
+        classes = random.sample(labels, k=self.n)
+        for cl in classes:
+            for idx in labels_to_indices[cl]:
+                task_description.append(DataDescription(idx))
+        return task_description
+
     def __call__(self, list task_description):
+        if task_description is None:
+            return self.new_task()
         cdef list classes = []
         cdef list result = []
         cdef set set_classes = set()
@@ -212,10 +261,9 @@ cdef class NWays(object):
             if self.indices_to_labels[dd.index] in classes:
                 result.append(dd)
         return result
-#        return [dd for dd in task_description if self.indices_to_labels[dd.index] in classes]
 
 
-class KShots(object):
+cdef class KShots(TaskTransform):
 
     """
     [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/data/transforms.py)
@@ -228,16 +276,23 @@ class KShots(object):
 
     * **dataset** (Dataset) - The dataset from which to load the sample.
     * **k** (int, *optional*, default=1) - The number of samples per label.
-    * **replacement** (bool, *optional*, default) - Whether to sample with replacement.
+    * **replacement** (bool, *optional*, default=False) - Whether to sample with replacement.
 
     """
 
+    cdef public:
+        long k
+        bool replacement
+
     def __init__(self, dataset, k=1, replacement=False):
+        super(KShots, self).__init__(dataset)
         self.dataset = dataset
         self.k = k
         self.replacement = replacement
 
     def __call__(self, task_description):
+        if task_description is None:
+            task_description = self.new_task()
         # TODO: The order of the data samples is not preserved.
         class_to_data = collections.defaultdict(list)
         for dd in task_description:
@@ -250,3 +305,67 @@ class KShots(object):
         else:
             sampler = random.sample
         return sum([sampler(dds, k=self.k) for dds in class_to_data.values()], [])
+
+
+cdef class FusedNWaysKShots(TaskTransform):
+
+    """
+    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/data/transforms.py)
+
+    **Description**
+
+    Efficient implementation of FilterLabels, NWays, and KShots.
+
+    **Arguments**
+
+    * **dataset** (Dataset) - The dataset from which to load the sample.
+    * **n** (int, *optional*, default=2) - Number of labels to sample from the task
+        description's labels.
+    * **k** (int, *optional*, default=1) - The number of samples per label.
+    * **replacement** (bool, *optional*, default=False) - Whether to sample shots with replacement.
+    * **filter_labels** (list, *optional*, default=None) - The list of labels to include. Defaults to
+        all labels in the dataset.
+    """
+
+    cdef public:
+        int n
+        int k
+        bool replacement
+        list filter_labels
+        object filtre
+        object nways
+        object kshots
+
+    def __init__(self, dataset, int n=2, int k=1, bool replacement=False, list filter_labels=None):
+        super(FusedNWaysKShots, self).__init__(dataset)
+        self.n = n
+        self.k = k
+        self.replacement = replacement
+        if filter_labels is None:
+            filter_labels = self.dataset.labels
+        self.filter_labels = filter_labels
+        self.filtre = FilterLabels(self.dataset, self.filter_labels)
+        self.nways = NWays(self.dataset, self.n)
+        self.kshots = KShots(self.dataset, k=self.k, replacement=self.replacement)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cpdef new_task(self):
+        cdef list task_description = []
+        labels = self.filter_labels
+        selected_labels = random.sample(labels, k=self.n)
+        for sl in selected_labels:
+            indices = self.dataset.labels_to_indices[sl]
+            if self.replacement:
+                selected_indices = [random.choice(indices) for _ in range(self.k)]
+            else:
+                selected_indices = random.sample(indices, k=self.k)
+            for idx in selected_indices:
+                task_description.append(DataDescription(idx))
+        return task_description
+
+    def __call__(self, task_description):
+        if task_description is None:
+            return self.new_task()
+        # Not fused
+        return self.kshots(self.nways(self.filtre(task_description)))

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ else:
 include_dirs = []
 compiler_directives = {'language_level': 3,
                        'embedsignature': True,
+#                       'profile': True,
 #                       'binding': True,
 }
 extensions = [

--- a/tests/integration/maml_omniglot_test.py
+++ b/tests/integration/maml_omniglot_test.py
@@ -76,9 +76,10 @@ def main(
     random.shuffle(classes)
 
     train_transforms = [
-        l2l.data.transforms.FilterLabels(dataset, classes[:1100]),
-        l2l.data.transforms.NWays(dataset, ways),
-        l2l.data.transforms.KShots(dataset, 2*shots),
+        l2l.data.transforms.FusedNWaysKShots(dataset,
+                                             n=ways,
+                                             k=2*shots,
+                                             filter_labels=classes[:1100]),
         l2l.data.transforms.LoadData(dataset),
         l2l.data.transforms.RemapLabels(dataset),
         l2l.data.transforms.ConsecutiveLabels(dataset),
@@ -89,9 +90,10 @@ def main(
                                        num_tasks=20000)
 
     valid_transforms = [
-        l2l.data.transforms.FilterLabels(dataset, classes[1100:1200]),
-        l2l.data.transforms.NWays(dataset, ways),
-        l2l.data.transforms.KShots(dataset, 2*shots),
+        l2l.data.transforms.FusedNWaysKShots(dataset,
+                                             n=ways,
+                                             k=2*shots,
+                                             filter_labels=classes[1100:1200]),
         l2l.data.transforms.LoadData(dataset),
         l2l.data.transforms.RemapLabels(dataset),
         l2l.data.transforms.ConsecutiveLabels(dataset),
@@ -102,9 +104,10 @@ def main(
                                        num_tasks=1024)
 
     test_transforms = [
-        l2l.data.transforms.FilterLabels(dataset, classes[1200:]),
-        l2l.data.transforms.NWays(dataset, ways),
-        l2l.data.transforms.KShots(dataset, 2*shots),
+        l2l.data.transforms.FusedNWaysKShots(dataset,
+                                             n=ways,
+                                             k=2*shots,
+                                             filter_labels=classes[1200:]),
         l2l.data.transforms.LoadData(dataset),
         l2l.data.transforms.RemapLabels(dataset),
         l2l.data.transforms.ConsecutiveLabels(dataset),


### PR DESCRIPTION
### Description

This PR accelerates task initialization by delegating it to the first task transform.

This PR also introduces the `FusedNWaysKShots`, which efficiently combines the `FilterLabels`, `NWays`, and `KShots` task transforms. On Omniglot, this translates to a 5x speed up in task sampling time.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [ ] My modifications are documented.

#### Optional

If you make major changes to the core library, please run `make alltests` and copy-paste the content of `alltests.txt` below.

~~~shell
make[1]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
OMP_NUM_THREADS=1 \
MKL_NUM_THREADS=1 \
python -W ignore -m unittest discover -s 'tests' -p '*_test.py' -v
test_final_accuracy (integration.maml_omniglot_test.MAMLOmniglotIntegrationTests) ... ok
test_adaptation (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_allow_nograd (unit.algorithms.maml_test.TestMAMLAlgorithm) ... Traceback (most recent call last):
  File "/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables/learn2learn/algorithms/maml.py", line 181, in adapt
    allow_unused=allow_unused)
  File "/home/seba-1511/anaconda3/lib/python3.7/site-packages/torch/autograd/__init__.py", line 157, in grad
    inputs, allow_unused)
RuntimeError: One of the differentiated Tensors does not require grad
ok
test_allow_unused (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_clone_module (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_graph_connection (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_adaptation (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_clone_module (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_graph_connection (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_meta_lr (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok

0it [00:00, ?it/s]
  0%|          | 0/9912422 [00:00<?, ?it/s]
  0%|          | 16384/9912422 [00:00<01:04, 153643.07it/s]
  1%|          | 98304/9912422 [00:00<00:50, 195962.30it/s]
  4%|▍         | 401408/9912422 [00:00<00:35, 269092.37it/s]
 16%|█▋        | 1622016/9912422 [00:00<00:21, 379371.26it/s]
 64%|██████▍   | 6381568/9912422 [00:00<00:06, 539364.45it/s]
9920512it [00:01, 9817508.20it/s]                            

0it [00:00, ?it/s]
  0%|          | 0/28881 [00:00<?, ?it/s]
32768it [00:00, 141776.90it/s]           

0it [00:00, ?it/s]
  0%|          | 0/1648877 [00:00<?, ?it/s]
  1%|          | 16384/1648877 [00:00<00:10, 152852.61it/s]
  6%|▌         | 98304/1648877 [00:00<00:07, 195063.92it/s]
 19%|█▉        | 319488/1648877 [00:00<00:05, 264004.24it/s]
 73%|███████▎  | 1204224/1648877 [00:00<00:01, 370474.70it/s]
1654784it [00:00, 2306714.00it/s]                            

0it [00:00, ?it/s]
  0%|          | 0/4542 [00:00<?, ?it/s]
8192it [00:00, 54890.65it/s]            

0it [00:00, ?it/s]
  0%|          | 0/9464212 [00:01<?, ?it/s]
9469952it [00:01, 6967500.07it/s]          

0it [00:00, ?it/s]
  0%|          | 0/6462886 [00:01<?, ?it/s]
6463488it [00:01, 5721626.61it/s]          
test_data_labels_length (unit.data.metadataset_test.TestMetaDataset) ... ok
test_data_labels_values (unit.data.metadataset_test.TestMetaDataset) ... ok
test_data_length (unit.data.metadataset_test.TestMetaDataset) ... ok
test_fails_with_non_torch_dataset (unit.data.metadataset_test.TestMetaDataset) ... ok
test_get_item (unit.data.metadataset_test.TestMetaDataset) ... ok
test_labels_to_indices (unit.data.metadataset_test.TestMetaDataset) ... ok
test_dataloader (unit.data.task_dataset_test.TestTaskDataset) ... Files already downloaded and verified
Files already downloaded and verified
0 Meta Train Accuracy 0.4375000107102096
1 Meta Train Accuracy 0.5062500089406967
2 Meta Train Accuracy 0.6062500127591193
3 Meta Train Accuracy 0.5125000104308128
4 Meta Train Accuracy 0.5437500113621354
learn2learn: Maybe try with allow_nograd=True and/or allow_unused=True ?
Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to /tmp/datasets/MNIST/raw/train-images-idx3-ubyte.gz
Extracting /tmp/datasets/MNIST/raw/train-images-idx3-ubyte.gz to /tmp/datasets/MNIST/raw
Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz to /tmp/datasets/MNIST/raw/train-labels-idx1-ubyte.gz
Extracting /tmp/datasets/MNIST/raw/train-labels-idx1-ubyte.gz to /tmp/datasets/MNIST/raw
Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz to /tmp/datasets/MNIST/raw/t10k-images-idx3-ubyte.gz
Extracting /tmp/datasets/MNIST/raw/t10k-images-idx3-ubyte.gz to /tmp/datasets/MNIST/raw
Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz to /tmp/datasets/MNIST/raw/t10k-labels-idx1-ubyte.gz
Extracting /tmp/datasets/MNIST/raw/t10k-labels-idx1-ubyte.gz to /tmp/datasets/MNIST/raw
Processing...
Done!
Downloading https://github.com/brendenlake/omniglot/raw/master/python/images_background.zip to /tmp/datasets/omniglot-py/images_background.zip
Extracting /tmp/datasets/omniglot-py/images_background.zip to /tmp/datasets/omniglot-py
Downloading https://github.com/brendenlake/omniglot/raw/master/python/images_evaluation.zip to /tmp/datasets/omniglot-py/images_evaluation.zip
Extracting /tmp/datasets/omniglot-py/images_evaluation.zip to /tmp/datasets/omniglot-py
ok
test_infinite_tasks (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_instanciation (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_task_caching (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_task_transforms (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_filter_labels (unit.data.transforms_test.TestTransforms) ... ok
test_k_shots (unit.data.transforms_test.TestTransforms) ... ok
test_load_data (unit.data.transforms_test.TestTransforms) ... ok
test_n_ways (unit.data.transforms_test.TestTransforms) ... ok
test_remap_labels (unit.data.transforms_test.TestTransforms) ... ok
test_distribution_clone (unit.utils_test.UtilTests) ... ok
test_distribution_detach (unit.utils_test.UtilTests) ... ok
test_module_clone (unit.utils_test.UtilTests) ... ok
test_module_detach (unit.utils_test.UtilTests) ... ok
test_download (unit.vision.cifarfs_test.CIFARFSTests) ... ok
test_download (unit.vision.fc100_test.FC100Tests) ... ok
test_download (unit.vision.fgvc_aircraft_test.AircraftTests) ... ok
test_download (unit.vision.vgg_flowers_test.FlowersTests) ... ok

----------------------------------------------------------------------
Ran 34 tests in 58.528s

OK
make lint
make[2]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
pycodestyle learn2learn/ --max-line-length=160
make[2]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
make[1]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
make[1]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
OMP_NUM_THREADS=1 \
MKL_NUM_THREADS=1 \
python -W ignore -m unittest discover -s 'tests' -p '*_test_notravis.py' -v
test_final_accuracy (integration.maml_miniimagenet_test_notravis.MAMLMiniImagenetIntegrationTests) ... ok
test_final_accuracy (integration.protonets_miniimagenet_test_notravis.ProtoNetMiniImageNetIntegrationTests) ... ok
test_download (unit.vision.tiered_imagenet_test_notravis.TieredImagenetTests) ... ok

----------------------------------------------------------------------
Ran 3 tests in 1879.319s

OK


Iteration 0
Meta Train Error 0.06558609916828573
Meta Train Accuracy 0.24999999813735485
Meta Valid Error 0.06655398570001125
Meta Valid Accuracy 0.21749999769963324
Meta Test Error 0.06511902599595487
Meta Test Accuracy 0.22999999951571226
epoch 1, train, loss=13.2611 acc=0.0848
epoch 1, val, loss=1.7404 acc=0.2805
batch 200: 27.06(29.33)
make[1]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'

~~~
