### PR TITLE
Fix using training labels in validation or test in some examples

### DIFF
--- a/examples/vision/anil_fc100.py
+++ b/examples/vision/anil_fc100.py
@@ -114,7 +114,7 @@ def main(
     valid_transforms = [
         FusedNWaysKShots(valid_dataset, n=ways, k=2*shots),
         LoadData(valid_dataset),
-        ConsecutiveLabels(train_dataset),
+        ConsecutiveLabels(valid_dataset),
         RemapLabels(valid_dataset),
     ]
     valid_tasks = l2l.data.TaskDataset(valid_dataset,
@@ -125,7 +125,7 @@ def main(
         FusedNWaysKShots(test_dataset, n=ways, k=2*shots),
         LoadData(test_dataset),
         RemapLabels(test_dataset),
-        ConsecutiveLabels(train_dataset),
+        ConsecutiveLabels(test_dataset),
     ]
     test_tasks = l2l.data.TaskDataset(test_dataset,
                                       task_transforms=test_transforms,

--- a/examples/vision/maml_miniimagenet.py
+++ b/examples/vision/maml_miniimagenet.py
@@ -84,7 +84,7 @@ def main(
         NWays(valid_dataset, ways),
         KShots(valid_dataset, 2*shots),
         LoadData(valid_dataset),
-        ConsecutiveLabels(train_dataset),
+        ConsecutiveLabels(valid_dataset),
         RemapLabels(valid_dataset),
     ]
     valid_tasks = l2l.data.TaskDataset(valid_dataset,

--- a/examples/vision/reptile_miniimagenet.py
+++ b/examples/vision/reptile_miniimagenet.py
@@ -121,7 +121,7 @@ def main(
         NWays(valid_dataset, ways),
         KShots(valid_dataset, 2*test_shots),
         LoadData(valid_dataset),
-        ConsecutiveLabels(train_dataset),
+        ConsecutiveLabels(valid_dataset),
         RemapLabels(valid_dataset),
     ]
     valid_tasks = l2l.data.TaskDataset(valid_dataset,
@@ -133,7 +133,7 @@ def main(
         KShots(test_dataset, 2*test_shots),
         LoadData(test_dataset),
         RemapLabels(test_dataset),
-        ConsecutiveLabels(train_dataset),
+        ConsecutiveLabels(test_dataset),
     ]
     test_tasks = l2l.data.TaskDataset(test_dataset,
                                       task_transforms=test_transforms,


### PR DESCRIPTION
Some examples (anil_fc100, maml_miniimagenet and reptile_miniimagenet) were using training labels in validation or test sets