### PR TITLE
Faster clone_module.

### DIFF
--- a/learn2learn/utils.py
+++ b/learn2learn/utils.py
@@ -92,16 +92,23 @@ def clone_module(module):
     #       clone = recursive_shallow_copy(model)
     #       clone._apply(lambda t: t.clone())
 
-    clone = copy.deepcopy(module)
+    # First, create a copy of the module.
+    # Adapted from:
+    # https://github.com/pytorch/pytorch/blob/65bad41cbec096aa767b3752843eddebf845726f/torch/nn/modules/module.py#L1171
+    clone = module.__new__(type(module))
+    clone.__dict__ = module.__dict__.copy()
+    clone._parameters = clone._parameters.copy()
+    clone._buffers = clone._buffers.copy()
+    clone._modules = clone._modules.copy()
 
-    # First, re-write all parameters
+    # Second, re-write all parameters
     if hasattr(clone, '_parameters'):
         for param_key in module._parameters:
             if module._parameters[param_key] is not None:
                 cloned = module._parameters[param_key].clone()
                 clone._parameters[param_key] = cloned
 
-    # Second, handle the buffers if necessary
+    # Third, handle the buffers if necessary
     if hasattr(clone, '_buffers'):
         for buffer_key in module._buffers:
             if clone._buffers[buffer_key] is not None and \

--- a/tests/integration/maml_miniimagenet_test_notravis.py
+++ b/tests/integration/maml_miniimagenet_test_notravis.py
@@ -50,7 +50,7 @@ def main(
         meta_batch_size=32,
         adaptation_steps=1,
         num_iterations=60000,
-        cuda=False,
+        cuda=True,
         seed=42,
 ):
     random.seed(seed)

--- a/tests/integration/protonets_miniimagenet_test_notravis.py
+++ b/tests/integration/protonets_miniimagenet_test_notravis.py
@@ -108,7 +108,7 @@ def main(num_iterations=250):
     setattr(args, 'gpu', 0)
 
     device = torch.device('cpu')
-    if args.gpu and torch.cuda.device_count():
+    if torch.cuda.device_count():
         torch.cuda.manual_seed(43)
         device = torch.device('cuda')
 
@@ -131,7 +131,7 @@ def main(num_iterations=250):
         l2l.data.transforms.RemapLabels(train_dataset),
     ]
     train_tasks = l2l.data.TaskDataset(train_dataset, task_transforms=train_transforms)
-    train_loader = DataLoader(train_tasks, pin_memory=True, shuffle=True)
+#    train_loader = DataLoader(train_tasks, pin_memory=True, shuffle=True)
 
     valid_dataset = l2l.data.MetaDataset(valid_dataset)
     valid_transforms = [
@@ -143,7 +143,7 @@ def main(num_iterations=250):
     valid_tasks = l2l.data.TaskDataset(valid_dataset,
                                        task_transforms=valid_transforms,
                                        num_tasks=200)
-    valid_loader = DataLoader(valid_tasks, pin_memory=True, shuffle=True)
+#    valid_loader = DataLoader(valid_tasks, pin_memory=True, shuffle=True)
 
     test_dataset = l2l.data.MetaDataset(test_dataset)
     test_transforms = [
@@ -155,7 +155,7 @@ def main(num_iterations=250):
     test_tasks = l2l.data.TaskDataset(test_dataset,
                                       task_transforms=test_transforms,
                                       num_tasks=200)
-    test_loader = DataLoader(test_tasks, pin_memory=True, shuffle=True)
+#    test_loader = DataLoader(test_tasks, pin_memory=True, shuffle=True)
 
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
     lr_scheduler = torch.optim.lr_scheduler.StepLR(
@@ -169,7 +169,8 @@ def main(num_iterations=250):
         n_acc = 0
 
         for i in range(100):
-            batch = next(iter(train_loader))
+#            batch = next(iter(train_loader))
+            batch = train_tasks.sample()
 
             loss, acc = fast_adapt(model,
                                    batch,
@@ -197,7 +198,7 @@ def main(num_iterations=250):
         loss_ctr = 0
         n_loss = 0
         n_acc = 0
-        for i, batch in enumerate(valid_loader):
+        for i, batch in enumerate(valid_tasks):
             loss, acc = fast_adapt(model,
                                    batch,
                                    args.test_way,
@@ -217,7 +218,7 @@ def main(num_iterations=250):
     loss_ctr = 0
     n_acc = 0
 
-    for i, batch in enumerate(test_loader, 1):
+    for i, batch in enumerate(test_tasks, 1):
         loss, acc = fast_adapt(model,
                                batch,
                                args.test_way,

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -1,8 +1,34 @@
 #!/usr/bin/env python3
 
 import unittest
+import copy
 import torch
 import learn2learn as l2l
+
+
+def ref_clone_module(module):
+    # First, create a copy of the module.
+    clone = copy.deepcopy(module)
+
+    # Second, re-write all parameters
+    if hasattr(clone, '_parameters'):
+        for param_key in module._parameters:
+            if module._parameters[param_key] is not None:
+                cloned = module._parameters[param_key].clone()
+                clone._parameters[param_key] = cloned
+
+    # Third, handle the buffers if necessary
+    if hasattr(clone, '_buffers'):
+        for buffer_key in module._buffers:
+            if clone._buffers[buffer_key] is not None and \
+                    clone._buffers[buffer_key].requires_grad:
+                clone._buffers[buffer_key] = module._buffers[buffer_key].clone()
+
+    # Then, recurse for each submodule
+    if hasattr(clone, '_modules'):
+        for module_key in clone._modules:
+            clone._modules[module_key] = ref_clone_module(module._modules[module_key])
+    return clone
 
 
 class Model(torch.nn.Module):
@@ -33,7 +59,7 @@ class UtilTests(unittest.TestCase):
         for param, gradient in zip(model.parameters(), gradients):
             param.data.sub_(0.01 * gradient)
 
-    def test_module_clone(self):
+    def test_clone_module_basics(self):
         original_output = self.model(self.input)
         original_loss = self.loss_func(original_output, torch.tensor([[0., 0.]]))
         original_gradients = torch.autograd.grad(original_loss,
@@ -55,7 +81,44 @@ class UtilTests(unittest.TestCase):
         self.optimizer_step(cloned_model, cloned_gradients)
 
         for a, b in zip(self.model.parameters(), cloned_model.parameters()):
-            assert torch.equal(a, b)
+            self.assertTrue(torch.equal(a, b))
+
+    def test_clone_module_models(self):
+        ref_models = [l2l.vision.models.OmniglotCNN(10),
+                  l2l.vision.models.MiniImagenetCNN(10)]
+        l2l_models = [copy.deepcopy(m) for m in ref_models]
+        inputs = [torch.randn(5, 1, 28, 28), torch.randn(5, 3, 84, 84)]
+
+
+        # Compute reference gradients
+        ref_grads = []
+        for model, X in zip(ref_models, inputs):
+            for iteration in range(10):
+                model.zero_grad()
+                clone = ref_clone_module(model)
+                out = clone(X)
+                out.norm(p=2).backward()
+                self.optimizer_step(model, [p.grad for p in model.parameters()])
+                ref_grads.append([p.grad.clone().detach() for p in model.parameters()])
+
+        # Compute cloned gradients
+        l2l_grads = []
+        for model, X in zip(l2l_models, inputs):
+            for iteration in range(10):
+                model.zero_grad()
+                clone = l2l.clone_module(model)
+                out = clone(X)
+                out.norm(p=2).backward()
+                self.optimizer_step(model, [p.grad for p in model.parameters()])
+                l2l_grads.append([p.grad.clone().detach() for p in model.parameters()])
+
+        # Compare gradients and model parameters
+        for ref_g, l2l_g in zip(ref_grads, l2l_grads):
+            for r_g, l_g in zip(ref_g, l2l_g):
+                self.assertTrue(torch.equal(r_g, l_g))
+        for ref_model, l2l_model in zip(ref_models, l2l_models):
+            for ref_p, l2l_p in zip(ref_model.parameters(), l2l_model.parameters()):
+                self.assertTrue(torch.equal(ref_p, l2l_p))
 
     def test_module_detach(self):
         original_output = self.model(self.input)


### PR DESCRIPTION
### Description

This small PR speeds-up `l2l.clone_module()` by replacing the deepcopy with a careful shallow copy.

On mini-ImageNet, this translates to a 35% speed-up.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [ ] My modifications are documented.

#### Optional

If you make major changes to the core library, please run `make alltests` and copy-paste the content of `alltests.txt` below.

~~~shell
make[1]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
OMP_NUM_THREADS=1 \
MKL_NUM_THREADS=1 \
python -W ignore -m unittest discover -s 'tests' -p '*_test.py' -v
test_final_accuracy (integration.maml_omniglot_test.MAMLOmniglotIntegrationTests) ... ok
test_adaptation (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_allow_nograd (unit.algorithms.maml_test.TestMAMLAlgorithm) ... Traceback (most recent call last):
  File "/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables/learn2learn/algorithms/maml.py", line 181, in adapt
    allow_unused=allow_unused)
  File "/home/seba-1511/anaconda3/lib/python3.7/site-packages/torch/autograd/__init__.py", line 157, in grad
    inputs, allow_unused)
RuntimeError: One of the differentiated Tensors does not require grad
ok
test_allow_unused (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_clone_module (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_graph_connection (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_adaptation (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_clone_module (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_graph_connection (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_meta_lr (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_data_labels_length (unit.data.metadataset_test.TestMetaDataset) ... ok
test_data_labels_values (unit.data.metadataset_test.TestMetaDataset) ... ok
test_data_length (unit.data.metadataset_test.TestMetaDataset) ... ok
test_fails_with_non_torch_dataset (unit.data.metadataset_test.TestMetaDataset) ... ok
test_get_item (unit.data.metadataset_test.TestMetaDataset) ... ok
test_labels_to_indices (unit.data.metadataset_test.TestMetaDataset) ... ok
test_dataloader (unit.data.task_dataset_test.TestTaskDataset) ... Files already downloaded and verified
Files already downloaded and verified
0 Meta Train Accuracy 0.38125000847503543
1 Meta Train Accuracy 0.4625000096857548
2 Meta Train Accuracy 0.4625000115483999
3 Meta Train Accuracy 0.5375000140629709
4 Meta Train Accuracy 0.5125000127591193
learn2learn: Maybe try with allow_nograd=True and/or allow_unused=True ?
Files already downloaded and verified
Files already downloaded and verified
ok
test_infinite_tasks (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_instanciation (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_task_caching (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_task_transforms (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_filter_labels (unit.data.transforms_test.TestTransforms) ... ok
test_k_shots (unit.data.transforms_test.TestTransforms) ... ok
test_load_data (unit.data.transforms_test.TestTransforms) ... ok
test_n_ways (unit.data.transforms_test.TestTransforms) ... ok
test_remap_labels (unit.data.transforms_test.TestTransforms) ... ok
test_clone_module_basics (unit.utils_test.UtilTests) ... ok
test_clone_module_models (unit.utils_test.UtilTests) ... ok
test_distribution_clone (unit.utils_test.UtilTests) ... ok
test_distribution_detach (unit.utils_test.UtilTests) ... ok
test_module_detach (unit.utils_test.UtilTests) ... ok
test_download (unit.vision.cifarfs_test.CIFARFSTests) ... ok
test_download (unit.vision.fc100_test.FC100Tests) ... ok
test_download (unit.vision.fgvc_aircraft_test.AircraftTests) ... ok
test_download (unit.vision.vgg_flowers_test.FlowersTests) ... ok

----------------------------------------------------------------------
Ran 35 tests in 26.426s

OK
make lint
make[2]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
pycodestyle learn2learn/ --max-line-length=160
make[2]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
make[1]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
make[1]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
OMP_NUM_THREADS=1 \
MKL_NUM_THREADS=1 \
python -W ignore -m unittest discover -s 'tests' -p '*_test_notravis.py' -v
test_final_accuracy (integration.maml_miniimagenet_test_notravis.MAMLMiniImagenetIntegrationTests) ... ok
test_final_accuracy (integration.protonets_miniimagenet_test_notravis.ProtoNetMiniImageNetIntegrationTests) ... ok
test_download (unit.vision.tiered_imagenet_test_notravis.TieredImagenetTests) ... ok

----------------------------------------------------------------------
Ran 3 tests in 415.912s

OK


Iteration 0
Meta Train Error 0.06558609916828573
Meta Train Accuracy 0.24999999813735485
Meta Valid Error 0.06655398570001125
Meta Valid Accuracy 0.21749999769963324
Meta Test Error 0.06511902599595487
Meta Test Accuracy 0.22999999951571226
epoch 1, train, loss=14.4017 acc=0.0841
epoch 1, val, loss=1.7298 acc=0.2955
batch 200: 28.23(20.67)
Downloading tiered ImageNet. (12Gb) Please be patient.
make[1]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'

~~~
