### PR TITLE
Make transforms compatible with pickle.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 .PHONY: *
 
 build:
+	rm -f learn2learn/**/*.so
+	rm -f learn2learn/**/*.c
 	python setup.py build_ext --inplace
 
 clean:

--- a/learn2learn/data/transforms.pyx
+++ b/learn2learn/data/transforms.pyx
@@ -122,13 +122,16 @@ cdef class CythonFilterLabels(TaskTransform):
     @cython.wraparound(False)
     def __init__(self, dataset, list labels):
         super(CythonFilterLabels, self).__init__(dataset)
-        cdef dict indices_to_labels = <dict>dataset.indices_to_labels
+        cdef dict indices_to_labels = dict(dataset.indices_to_labels)
         cdef long len_dataset = len(dataset)
         cdef long i
         self.labels = labels
         self.filtered_indices = array.array('i', [0] * len_dataset)
         for i in range(len_dataset):
             self.filtered_indices[i] = int(indices_to_labels[i] in self.labels)
+
+    def __reduce__(self):
+        return CythonFilterLabels, (self.dataset, self.labels)
 
     def __call__(self, list task_description):
         if task_description is None:
@@ -243,14 +246,17 @@ cdef class CythonNWays(TaskTransform):
     def __init__(self, dataset, int n=2):
         super(CythonNWays, self).__init__(dataset)
         self.n = n
-        self.indices_to_labels = <dict>dataset.indices_to_labels
+        self.indices_to_labels = dict(dataset.indices_to_labels)
+
+    def __reduce__(self):
+        return CythonNWays, (self.dataset, self.n)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     cpdef new_task(self):  # Efficient initializer
         cdef list labels = self.dataset.labels
         cdef list task_description = []
-        cdef dict labels_to_indices = <dict>self.dataset.labels_to_indices
+        cdef dict labels_to_indices = dict(self.dataset.labels_to_indices)
         classes = random.sample(labels, k=self.n)
         for cl in classes:
             for idx in labels_to_indices[cl]:
@@ -306,6 +312,9 @@ cdef class CythonKShots(TaskTransform):
         self.dataset = dataset
         self.k = k
         self.replacement = replacement
+
+    def __reduce__(self):
+        return CythonKShots, (self.dataset, self.k, self.replacement)
 
     def __call__(self, task_description):
         if task_description is None:
@@ -375,6 +384,13 @@ cdef class CythonFusedNWaysKShots(TaskTransform):
         self.filtre = FilterLabels(self.dataset, self.filter_labels)
         self.nways = NWays(self.dataset, self.n)
         self.kshots = KShots(self.dataset, k=self.k, replacement=self.replacement)
+
+    def __reduce__(self):
+        return CythonFusedNWaysKShots, (self.dataset,
+                                        self.n,
+                                        self.k,
+                                        self.replacement,
+                                        self.filter_labels)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ else:
 # https://github.com/FedericoStra/cython-package-example/blob/master/setup.py
 extension_type = '.c'
 cmd_class = {}
-use_cython = 'develop' in sys.argv
+use_cython = 'develop' in sys.argv or 'build_ext' in sys.argv
 if use_cython:
     from Cython.Build import cythonize
     from Cython.Distutils import build_ext


### PR DESCRIPTION
### Description

Makes Cython transforms compatible with pickle by adding a `__reduce__` method.

This is useful for pickling them to file or to share them via multi-processing.

Reference: [https://github.com/cython/cython/blob/master/tests/run/reduce_pickle.pyx](https://github.com/cython/cython/blob/master/tests/run/reduce_pickle.pyx)

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [ ] My modifications are tested.
- [ ] My modifications are documented.
