### PR TITLE
Use iterools.chain instead of sum to flatten list + Fix variable Typo 

### DIFF
--- a/learn2learn/data/transforms.pyx
+++ b/learn2learn/data/transforms.pyx
@@ -381,7 +381,7 @@ cdef class CythonFusedNWaysKShots(TaskTransform):
         if filter_labels is None:
             filter_labels = self.dataset.labels
         self.filter_labels = filter_labels
-        self.filtre = FilterLabels(self.dataset, self.filter_labels)
+        self.filter = FilterLabels(self.dataset, self.filter_labels)
         self.nways = NWays(self.dataset, self.n)
         self.kshots = KShots(self.dataset, k=self.k, replacement=self.replacement)
 
@@ -412,4 +412,4 @@ cdef class CythonFusedNWaysKShots(TaskTransform):
         if task_description is None:
             return self.new_task()
         # Not fused
-        return self.kshots(self.nways(self.filtre(task_description)))
+        return self.kshots(self.nways(self.filter(task_description)))

--- a/learn2learn/data/transforms.pyx
+++ b/learn2learn/data/transforms.pyx
@@ -38,6 +38,7 @@ import random
 import collections
 import functools
 import array
+import itertools
 
 from .task_dataset cimport DataDescription
 from .task_dataset import DataDescription
@@ -330,7 +331,8 @@ cdef class CythonKShots(TaskTransform):
                         for dd in random.choices(x, k=k)]
         else:
             sampler = random.sample
-        return sum([sampler(dds, k=self.k) for dds in class_to_data.values()], [])
+
+        return list(itertools.chain(*[sampler(dds, k=self.k) for dds in class_to_data.values()]))
 
 
 class FusedNWaysKShots(CythonFusedNWaysKShots):


### PR DESCRIPTION
### Description

- `sum(list_of_list, [])` is inefficient. Read [here](https://stackoverflow.com/questions/952914/how-to-make-a-flat-list-out-of-list-of-lists)
- A small typo fix in the code.

PS : We can merge it with some other bigger PR if we want to avoid small 1 line commits.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
