### PR TITLE
Improve clone_module support for non Module objects.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - 'TV=0.4.0 TORCH=1.2.0'
     - 'TV=0.4.1 TORCH=1.3.0'
     - 'TV=0.5.0 TORCH=1.4.0'
+    - 'TV=0.6.0 TORCH=1.5.0'
 
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* clone_module supports non-Module objects.
+
 
 ## v0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * clone_module supports non-Module objects.
+* VGG flowers now relies on tarfile.open() instead of tarfile.TarFile().
 
 
 ## v0.1.1

--- a/learn2learn/utils.py
+++ b/learn2learn/utils.py
@@ -95,6 +95,8 @@ def clone_module(module):
     # First, create a copy of the module.
     # Adapted from:
     # https://github.com/pytorch/pytorch/blob/65bad41cbec096aa767b3752843eddebf845726f/torch/nn/modules/module.py#L1171
+    if not isinstance(module, torch.nn.Module):
+        return module
     clone = module.__new__(type(module))
     clone.__dict__ = module.__dict__.copy()
     clone._parameters = clone._parameters.copy()
@@ -152,6 +154,8 @@ def detach_module(module):
     error.backward()  # Gradients are back-propagate on clone, not net.
     ~~~
     """
+    if not isinstance(module, torch.nn.Module):
+        return
     # First, re-write all parameters
     for param_key in module._parameters:
         if module._parameters[param_key] is not None:

--- a/learn2learn/vision/datasets/vgg_flowers.py
+++ b/learn2learn/vision/datasets/vgg_flowers.py
@@ -91,8 +91,9 @@ class VGGFlower102(Dataset):
         req = requests.get(IMAGES_URL)
         with open(tar_path, 'wb') as archive:
             archive.write(req.content)
-        tar_file = tarfile.TarFile(tar_path)
+        tar_file = tarfile.open(tar_path)
         tar_file.extractall(data_path)
+        tar_file.close()
         os.remove(tar_path)
 
         label_path = os.path.join(data_path, os.path.basename(LABELS_URL))
@@ -134,5 +135,5 @@ if __name__ == '__main__':
     assert len(SPLITS['validation']) == 15
     assert len(SPLITS['test']) == 16
     assert len(SPLITS['all']) == 102
-    flowers = VGGFlower102('~/data', download=True)
+    flowers = VGGFlower102('~/vgg_data', download=True)
     print(len(flowers))

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -90,6 +90,26 @@ class UtilTests(unittest.TestCase):
         for a, b in zip(self.model.parameters(), cloned_model.parameters()):
             self.assertTrue(torch.equal(a, b))
 
+    def test_clone_module_nomodule(self):
+        # Tests that we can clone non-module objects
+        class TrickyModule(torch.nn.Module):
+
+            def __init__(self):
+                super(TrickyModule, self).__init__()
+                self.tricky_modules = torch.nn.ModuleList([
+                    torch.nn.Linear(2, 1),
+                    None,
+                    torch.nn.Linear(1, 1),
+                ])
+
+        model = TrickyModule()
+        clone = l2l.clone_module(model)
+        for i, submodule in enumerate(clone.tricky_modules):
+            if i % 2 == 0:
+                self.assertTrue(submodule is not None)
+            else:
+                self.assertTrue(submodule is None)
+
     def test_clone_module_models(self):
         ref_models = [l2l.vision.models.OmniglotCNN(10),
                   l2l.vision.models.MiniImagenetCNN(10)]


### PR DESCRIPTION
### Description

clone_module now returns the object if it is not an instance of torch.nn.Module.
As a minor fix to tests on travis, I also changed `tarfile.TarFile` to `tarfile.open` in VGG.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [ ] My modifications are documented.
