### PR TITLE
Add l2l.vision.benchmarks interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add l2l.vision.benchmarks interface.
+
 ### Changed
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,11 @@ alltests:
 	make notravis-tests >>alltests.txt 2>&1
 
 docs:
+	rm -f docs/mkdocs.yml
 	cd docs && pydocmd build && pydocmd serve
 
 docs-deploy:
+	rm -f docs/mkdocs.yml
 	cd docs && pydocmd gh-deploy
 
 # https://dev.to/neshaz/a-tutorial-for-tagging-releases-in-git-147e

--- a/docs/pydocmd.yml
+++ b/docs/pydocmd.yml
@@ -56,7 +56,7 @@ generate:
               - learn2learn.vision.datasets.FGVCAircraft
           - learn2learn.vision.transforms:
               - learn2learn.vision.transforms.RandomClassRotation
-          - learn2learn.vision.benchmarks++:
+          - learn2learn.vision.benchmarks:
               - learn2learn.vision.benchmarks.list_tasksets
               - learn2learn.vision.benchmarks.get_tasksets
   - docs/learn2learn.text.md:

--- a/docs/pydocmd.yml
+++ b/docs/pydocmd.yml
@@ -96,13 +96,13 @@ repo_name: 'learnables/learn2learn'
 repo_url: 'https://github.com/learnables/learn2learn'
 
 theme:
-  name: 'material'
-  logo: 'assets/img/learn2learn_white.png'
-  favicon: 'assets/img/favicons/favicon.ico'
-  palette:
-      primary: 'blue'
-      accent: 'orange'
-  font:
+    name: 'material'
+    logo: 'assets/img/learn2learn_white.png'
+    favicon: 'assets/img/favicons/favicon.ico'
+    palette:
+        primary: 'blue'
+        accent: 'orange'
+    font:
     text: 'Source Sans Pro'
     code: 'Ubuntu Mono'
 
@@ -130,22 +130,22 @@ headers: markdown
 # subdirectory of your project (eg. docs/), you may want to add the parent
 # directory here.
 additional_search_paths:
-  - ..
+    - ..
 
 extra_javascript:
-  - https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js
-  - https://cdn.jsdelivr.net/npm/katex/dist/contrib/mathtex-script-type.min.js
+    - https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js
+    - https://cdn.jsdelivr.net/npm/katex/dist/contrib/mathtex-script-type.min.js
 
 extra_css:
-  - https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css
-  - 'assets/css/l2l_material.css'
+    - https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css
+    - 'assets/css/l2l_material.css'
 
 # Extensions
 markdown_extensions:
-  - mdx_math
-  - admonition
-  - codehilite:
-      guess_lang: true
-      linenums: true
-  - toc:
-      permalink: true
+    - mdx_math
+    - admonition
+    - codehilite:
+        guess_lang: true
+        linenums: true
+    - toc:
+        permalink: true

--- a/docs/pydocmd.yml
+++ b/docs/pydocmd.yml
@@ -103,8 +103,8 @@ theme:
         primary: 'blue'
         accent: 'orange'
     font:
-    text: 'Source Sans Pro'
-    code: 'Ubuntu Mono'
+        text: 'Source Sans Pro'
+        code: 'Ubuntu Mono'
 
 extra:
   social:

--- a/docs/pydocmd.yml
+++ b/docs/pydocmd.yml
@@ -56,6 +56,9 @@ generate:
               - learn2learn.vision.datasets.FGVCAircraft
           - learn2learn.vision.transforms:
               - learn2learn.vision.transforms.RandomClassRotation
+          - learn2learn.vision.benchmarks++:
+              - learn2learn.vision.benchmarks.list_tasksets
+              - learn2learn.vision.benchmarks.get_tasksets
   - docs/learn2learn.text.md:
       - learn2learn.text.datasets.NewsClassification
 

--- a/learn2learn/vision/__init__.py
+++ b/learn2learn/vision/__init__.py
@@ -3,3 +3,4 @@
 from . import datasets
 from . import models
 from . import transforms
+from . import benchmarks

--- a/learn2learn/vision/benchmarks/__init__.py
+++ b/learn2learn/vision/benchmarks/__init__.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 
 """
-l2l.vision.benchmarks documentation.
+The benchmark modules provides a convenient interface to standardized benchmarks in the literature.
+It provides train/validation/test TaskDatasets and TaskTransforms for pre-defined datasets.
+
+This utility is useful for researchers to compare new algorithms against existing benchmarks.
+For a more fine-grained control over tasks and data, we recommend directly using `l2l.data.TaskDataset` and `l2l.data.TaskTransforms`.
 """
 
 import os
@@ -35,15 +39,13 @@ def list_tasksets():
 
     **Description**
 
-    **Arguments**
-
-    * **model** (Module) - The model to update.
-    * **lr** (float) - The learning rate used to update the model.
-    * **grads** (list, *optional*, default=None) - A list of gradients for each parameter
-        of the model. If None, will use the gradients in .grad attributes.
+    Returns a list of all available benchmarks.
 
     **Example**
     ~~~python
+    for name in l2l.vision.benchmarks.list_tasksets():
+        print(name)
+        tasksets = l2l.vision.benchmarks.get_tasksets(name)
     ~~~
     """
     return _TASKSETS.keys()
@@ -65,15 +67,29 @@ def get_tasksets(
 
     **Description**
 
+    Returns the tasksets for a particular benchmark, using literature standard data and task transformations.
+
+    The returned object is a namedtuple with attributes `train`, `validation`, `test` which
+    correspond to their respective TaskDatasets.
+    See `examples/vision/maml_miniimagenet.py` for an example.
+
     **Arguments**
 
-    * **model** (Module) - The model to update.
-    * **lr** (float) - The learning rate used to update the model.
-    * **grads** (list, *optional*, default=None) - A list of gradients for each parameter
-        of the model. If None, will use the gradients in .grad attributes.
+    * **name** (str) - The name of the benchmark. Full list in `list_tasksets()`.
+    * **train_ways** (int, *optional*, default=5) - The number of classes per train tasks.
+    * **train_samples** (int, *optional*, default=10) - The number of samples per train tasks.
+    * **test_ways** (int, *optional*, default=5) - The number of classes per test tasks.
+    * **test_samples** (int, *optional*, default=10) - The number of samples per test tasks.
+    * **num_tasks** (int, *optional*, default=-1) - The number of tasks in each TaskDataset.
+    * **root** (str, *optional*, default='~/data') - Where the data is stored.
 
     **Example**
     ~~~python
+    train_tasks, validation_tasks, test_tasks = l2l.vision.benchmarks.get_tasksets('omniglot')
+    batch = train_tasks.sample()
+    # or:
+    tasksets = l2l.vision.benchmarks.get_tasksets('omniglot')
+    batch = tasksets.train.sample()
     ~~~
     """
     root = os.path.expanduser(root)

--- a/learn2learn/vision/benchmarks/__init__.py
+++ b/learn2learn/vision/benchmarks/__init__.py
@@ -10,6 +10,9 @@ import learn2learn as l2l
 from collections import namedtuple
 from .omniglot_benchmark import omniglot_tasksets
 from .mini_imagenet_benchmark import mini_imagenet_tasksets
+from .tiered_imagenet_benchmark import tiered_imagenet_tasksets
+from .fc100_benchmark import fc100_tasksets
+from .cifarfs_benchmark import cifarfs_tasksets
 
 
 __all__ = ['list_tasksets', 'get_tasksets']
@@ -20,6 +23,9 @@ BenchmarkTasksets = namedtuple('BenchmarkTasksets', ('train', 'validation', 'tes
 _TASKSETS = {
     'omniglot': omniglot_tasksets,
     'mini-imagenet': mini_imagenet_tasksets,
+    'tiered-imagenet': tiered_imagenet_tasksets,
+    'fc100': fc100_tasksets,
+    'cifarfs': cifarfs_tasksets,
 }
 
 

--- a/learn2learn/vision/benchmarks/__init__.py
+++ b/learn2learn/vision/benchmarks/__init__.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+"""
+l2l.vision.benchmarks documentation.
+"""
+
+import os
+import learn2learn as l2l
+
+from collections import namedtuple
+from .omniglot_benchmark import omniglot_tasksets
+
+BenchmarkTasksets = namedtuple('BenchmarkTasksets', ('train', 'validation', 'test'))
+
+_TASKSETS = {
+        'omniglot': omniglot_tasksets
+        }
+
+
+def list_tasksets():
+    """
+    Output: 
+    """
+    return _TASKSETS.keys()
+
+
+def get_tasksets(
+    name,
+    train_ways=5,
+    train_samples=10,
+    test_ways=5,
+    test_samples=10,
+    num_tasks=-1,
+    root='~/data',
+    device=None,
+    **kwargs,
+    ):
+    """
+    Pass
+    """
+    root = os.path.expanduser(root)
+
+    if device is not None:
+        raise NotImplementedError('Device other than None not implemented. (yet)')
+
+    # Load task-specific data and transforms
+    datasets, transforms = _TASKSETS[name](train_ways=train_ways,
+        train_samples=train_samples,
+        test_ways=test_ways,
+        test_samples=test_samples,
+        root=root,
+        **kwargs,
+    )
+    train_dataset, validation_dataset, test_dataset = datasets
+    train_transforms, validation_transforms, test_transforms = transforms
+
+    # Instantiate the tasksets
+    train_tasks = l2l.data.TaskDataset(
+        dataset=train_dataset,
+        task_transforms=train_transforms,
+        num_tasks=num_tasks,
+    )
+    validation_tasks = l2l.data.TaskDataset(
+        dataset=validation_dataset,
+        task_transforms=validation_transforms,
+        num_tasks=num_tasks,
+    )
+    test_tasks = l2l.data.TaskDataset(
+        dataset=test_dataset,
+        task_transforms=test_transforms,
+        num_tasks=num_tasks,
+    )
+    return BenchmarkTasksets(train_tasks, validation_tasks, test_tasks)

--- a/learn2learn/vision/benchmarks/__init__.py
+++ b/learn2learn/vision/benchmarks/__init__.py
@@ -88,7 +88,7 @@ def get_tasksets(
     train_tasks, validation_tasks, test_tasks = l2l.vision.benchmarks.get_tasksets('omniglot')
     batch = train_tasks.sample()
 
-    # or:
+    or:
 
     tasksets = l2l.vision.benchmarks.get_tasksets('omniglot')
     batch = tasksets.train.sample()

--- a/learn2learn/vision/benchmarks/__init__.py
+++ b/learn2learn/vision/benchmarks/__init__.py
@@ -31,7 +31,20 @@ _TASKSETS = {
 
 def list_tasksets():
     """
-    Output: 
+    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/vision/benchmarks/)
+
+    **Description**
+
+    **Arguments**
+
+    * **model** (Module) - The model to update.
+    * **lr** (float) - The learning rate used to update the model.
+    * **grads** (list, *optional*, default=None) - A list of gradients for each parameter
+        of the model. If None, will use the gradients in .grad attributes.
+
+    **Example**
+    ~~~python
+    ~~~
     """
     return _TASKSETS.keys()
 
@@ -46,9 +59,22 @@ def get_tasksets(
     root='~/data',
     device=None,
     **kwargs,
-    ):
+):
     """
-    Pass
+    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/vision/benchmarks/)
+
+    **Description**
+
+    **Arguments**
+
+    * **model** (Module) - The model to update.
+    * **lr** (float) - The learning rate used to update the model.
+    * **grads** (list, *optional*, default=None) - A list of gradients for each parameter
+        of the model. If None, will use the gradients in .grad attributes.
+
+    **Example**
+    ~~~python
+    ~~~
     """
     root = os.path.expanduser(root)
 
@@ -57,12 +83,11 @@ def get_tasksets(
 
     # Load task-specific data and transforms
     datasets, transforms = _TASKSETS[name](train_ways=train_ways,
-        train_samples=train_samples,
-        test_ways=test_ways,
-        test_samples=test_samples,
-        root=root,
-        **kwargs,
-    )
+                                           train_samples=train_samples,
+                                           test_ways=test_ways,
+                                           test_samples=test_samples,
+                                           root=root,
+                                           **kwargs)
     train_dataset, validation_dataset, test_dataset = datasets
     train_transforms, validation_transforms, test_transforms = transforms
 

--- a/learn2learn/vision/benchmarks/__init__.py
+++ b/learn2learn/vision/benchmarks/__init__.py
@@ -9,12 +9,18 @@ import learn2learn as l2l
 
 from collections import namedtuple
 from .omniglot_benchmark import omniglot_tasksets
+from .mini_imagenet_benchmark import mini_imagenet_tasksets
+
+
+__all__ = ['list_tasksets', 'get_tasksets']
+
 
 BenchmarkTasksets = namedtuple('BenchmarkTasksets', ('train', 'validation', 'test'))
 
 _TASKSETS = {
-        'omniglot': omniglot_tasksets
-        }
+    'omniglot': omniglot_tasksets,
+    'mini-imagenet': mini_imagenet_tasksets,
+}
 
 
 def list_tasksets():

--- a/learn2learn/vision/benchmarks/__init__.py
+++ b/learn2learn/vision/benchmarks/__init__.py
@@ -78,8 +78,8 @@ def get_tasksets(
     * **name** (str) - The name of the benchmark. Full list in `list_tasksets()`.
     * **train_ways** (int, *optional*, default=5) - The number of classes per train tasks.
     * **train_samples** (int, *optional*, default=10) - The number of samples per train tasks.
-    * **test_ways** (int, *optional*, default=5) - The number of classes per test tasks.
-    * **test_samples** (int, *optional*, default=10) - The number of samples per test tasks.
+    * **test_ways** (int, *optional*, default=5) - The number of classes per test tasks. Also used for validation tasks.
+    * **test_samples** (int, *optional*, default=10) - The number of samples per test tasks. Also used for validation tasks.
     * **num_tasks** (int, *optional*, default=-1) - The number of tasks in each TaskDataset.
     * **root** (str, *optional*, default='~/data') - Where the data is stored.
 
@@ -87,7 +87,9 @@ def get_tasksets(
     ~~~python
     train_tasks, validation_tasks, test_tasks = l2l.vision.benchmarks.get_tasksets('omniglot')
     batch = train_tasks.sample()
+
     # or:
+
     tasksets = l2l.vision.benchmarks.get_tasksets('omniglot')
     batch = tasksets.train.sample()
     ~~~

--- a/learn2learn/vision/benchmarks/cifarfs_benchmark.py
+++ b/learn2learn/vision/benchmarks/cifarfs_benchmark.py
@@ -5,6 +5,7 @@ import learn2learn as l2l
 
 from learn2learn.data.transforms import NWays, KShots, LoadData, RemapLabels, ConsecutiveLabels
 
+
 def cifarfs_tasksets(
     train_ways=5,
     train_samples=10,
@@ -12,7 +13,7 @@ def cifarfs_tasksets(
     test_samples=10,
     root='~/data',
     **kwargs,
-    ):
+):
     """Tasksets for CIFAR-FS benchmarks."""
     data_transform = tv.transforms.ToTensor()
     train_dataset = l2l.vision.datasets.CIFARFS(root=root,
@@ -53,4 +54,3 @@ def cifarfs_tasksets(
     _datasets = (train_dataset, valid_dataset, test_dataset)
     _transforms = (train_transforms, valid_transforms, test_transforms)
     return _datasets, _transforms
-    

--- a/learn2learn/vision/benchmarks/cifarfs_benchmark.py
+++ b/learn2learn/vision/benchmarks/cifarfs_benchmark.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
+import torchvision as tv
 import learn2learn as l2l
+
 from learn2learn.data.transforms import NWays, KShots, LoadData, RemapLabels, ConsecutiveLabels
 
-def mini_imagenet_tasksets(
+def cifarfs_tasksets(
     train_ways=5,
     train_samples=10,
     test_ways=5,
@@ -11,10 +13,17 @@ def mini_imagenet_tasksets(
     root='~/data',
     **kwargs,
     ):
-    """Tasksets for mini-ImageNet benchmarks."""
-    train_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='train')
-    valid_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='validation')
-    test_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='test')
+    """Tasksets for CIFAR-FS benchmarks."""
+    data_transform = tv.transforms.ToTensor()
+    train_dataset = l2l.vision.datasets.CIFARFS(root=root,
+                                                transform=data_transform,
+                                                mode='train')
+    valid_dataset = l2l.vision.datasets.CIFARFS(root=root,
+                                                transform=data_transform,
+                                                mode='validation')
+    test_dataset = l2l.vision.datasets.CIFARFS(root=root,
+                                               transform=data_transform,
+                                               mode='test')
     train_dataset = l2l.data.MetaDataset(train_dataset)
     valid_dataset = l2l.data.MetaDataset(valid_dataset)
     test_dataset = l2l.data.MetaDataset(test_dataset)

--- a/learn2learn/vision/benchmarks/cifarfs_benchmark.py
+++ b/learn2learn/vision/benchmarks/cifarfs_benchmark.py
@@ -18,13 +18,16 @@ def cifarfs_tasksets(
     data_transform = tv.transforms.ToTensor()
     train_dataset = l2l.vision.datasets.CIFARFS(root=root,
                                                 transform=data_transform,
-                                                mode='train')
+                                                mode='train',
+                                                download=True)
     valid_dataset = l2l.vision.datasets.CIFARFS(root=root,
                                                 transform=data_transform,
-                                                mode='validation')
+                                                mode='validation',
+                                                download=True)
     test_dataset = l2l.vision.datasets.CIFARFS(root=root,
                                                transform=data_transform,
-                                               mode='test')
+                                               mode='test',
+                                               download=True)
     train_dataset = l2l.data.MetaDataset(train_dataset)
     valid_dataset = l2l.data.MetaDataset(valid_dataset)
     test_dataset = l2l.data.MetaDataset(test_dataset)

--- a/learn2learn/vision/benchmarks/fc100_benchmark.py
+++ b/learn2learn/vision/benchmarks/fc100_benchmark.py
@@ -18,13 +18,16 @@ def fc100_tasksets(
     data_transform = tv.transforms.ToTensor()
     train_dataset = l2l.vision.datasets.FC100(root=root,
                                               transform=data_transform,
-                                              mode='train')
+                                              mode='train',
+                                              download=True)
     valid_dataset = l2l.vision.datasets.FC100(root=root,
                                               transform=data_transform,
-                                              mode='validation')
+                                              mode='validation',
+                                              download=True)
     test_dataset = l2l.vision.datasets.FC100(root=root,
                                              transform=data_transform,
-                                             mode='test')
+                                             mode='test',
+                                             download=True)
     train_dataset = l2l.data.MetaDataset(train_dataset)
     valid_dataset = l2l.data.MetaDataset(valid_dataset)
     test_dataset = l2l.data.MetaDataset(test_dataset)

--- a/learn2learn/vision/benchmarks/fc100_benchmark.py
+++ b/learn2learn/vision/benchmarks/fc100_benchmark.py
@@ -5,6 +5,7 @@ import learn2learn as l2l
 
 from learn2learn.data.transforms import NWays, KShots, LoadData, RemapLabels, ConsecutiveLabels
 
+
 def fc100_tasksets(
     train_ways=5,
     train_samples=10,
@@ -12,7 +13,7 @@ def fc100_tasksets(
     test_samples=10,
     root='~/data',
     **kwargs,
-    ):
+):
     """Tasksets for FC100 benchmarks."""
     data_transform = tv.transforms.ToTensor()
     train_dataset = l2l.vision.datasets.FC100(root=root,
@@ -53,4 +54,3 @@ def fc100_tasksets(
     _datasets = (train_dataset, valid_dataset, test_dataset)
     _transforms = (train_transforms, valid_transforms, test_transforms)
     return _datasets, _transforms
-    

--- a/learn2learn/vision/benchmarks/fc100_benchmark.py
+++ b/learn2learn/vision/benchmarks/fc100_benchmark.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
+import torchvision as tv
 import learn2learn as l2l
+
 from learn2learn.data.transforms import NWays, KShots, LoadData, RemapLabels, ConsecutiveLabels
 
-def mini_imagenet_tasksets(
+def fc100_tasksets(
     train_ways=5,
     train_samples=10,
     test_ways=5,
@@ -11,10 +13,17 @@ def mini_imagenet_tasksets(
     root='~/data',
     **kwargs,
     ):
-    """Tasksets for mini-ImageNet benchmarks."""
-    train_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='train')
-    valid_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='validation')
-    test_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='test')
+    """Tasksets for FC100 benchmarks."""
+    data_transform = tv.transforms.ToTensor()
+    train_dataset = l2l.vision.datasets.FC100(root=root,
+                                              transform=data_transform,
+                                              mode='train')
+    valid_dataset = l2l.vision.datasets.FC100(root=root,
+                                              transform=data_transform,
+                                              mode='validation')
+    test_dataset = l2l.vision.datasets.FC100(root=root,
+                                             transform=data_transform,
+                                             mode='test')
     train_dataset = l2l.data.MetaDataset(train_dataset)
     valid_dataset = l2l.data.MetaDataset(valid_dataset)
     test_dataset = l2l.data.MetaDataset(test_dataset)

--- a/learn2learn/vision/benchmarks/mini_imagenet_benchmark.py
+++ b/learn2learn/vision/benchmarks/mini_imagenet_benchmark.py
@@ -13,9 +13,15 @@ def mini_imagenet_tasksets(
     **kwargs,
 ):
     """Tasksets for mini-ImageNet benchmarks."""
-    train_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='train')
-    valid_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='validation')
-    test_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='test')
+    train_dataset = l2l.vision.datasets.MiniImagenet(root=root,
+                                                     mode='train',
+                                                     download=True)
+    valid_dataset = l2l.vision.datasets.MiniImagenet(root=root,
+                                                     mode='validation',
+                                                     download=True)
+    test_dataset = l2l.vision.datasets.MiniImagenet(root=root,
+                                                    mode='test',
+                                                    download=True)
     train_dataset = l2l.data.MetaDataset(train_dataset)
     valid_dataset = l2l.data.MetaDataset(valid_dataset)
     test_dataset = l2l.data.MetaDataset(test_dataset)

--- a/learn2learn/vision/benchmarks/mini_imagenet_benchmark.py
+++ b/learn2learn/vision/benchmarks/mini_imagenet_benchmark.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import learn2learn as l2l
+from learn2learn.data.transforms import NWays, KShots, LoadData, RemapLabels, ConsecutiveLabels
+
+def mini_imagenet_tasksets(
+    train_ways=5,
+    train_samples=10,
+    test_ways=5,
+    test_samples=10,
+    root='~/data',
+
+    ):
+    """Tasksets for mini-ImageNet benchmarks."""
+    train_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='train')
+    valid_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='validation')
+    test_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='test')
+    train_dataset = l2l.data.MetaDataset(train_dataset)
+    valid_dataset = l2l.data.MetaDataset(valid_dataset)
+    test_dataset = l2l.data.MetaDataset(test_dataset)
+
+    train_transforms = [
+        NWays(train_dataset, train_ways),
+        KShots(train_dataset, train_samples),
+        LoadData(train_dataset),
+        RemapLabels(train_dataset),
+        ConsecutiveLabels(train_dataset),
+    ]
+    valid_transforms = [
+        NWays(valid_dataset, test_ways),
+        KShots(valid_dataset, test_samples),
+        LoadData(valid_dataset),
+        ConsecutiveLabels(valid_dataset),
+        RemapLabels(valid_dataset),
+    ]
+    test_transforms = [
+        NWays(test_dataset, test_ways),
+        KShots(test_dataset, test_samples),
+        LoadData(test_dataset),
+        RemapLabels(test_dataset),
+        ConsecutiveLabels(test_dataset),
+    ]
+
+    _datasets = (train_dataset, valid_dataset, test_dataset)
+    _transforms = (train_transforms, valid_transforms, test_transforms)
+    return _datasets, _transforms
+    

--- a/learn2learn/vision/benchmarks/mini_imagenet_benchmark.py
+++ b/learn2learn/vision/benchmarks/mini_imagenet_benchmark.py
@@ -3,6 +3,7 @@
 import learn2learn as l2l
 from learn2learn.data.transforms import NWays, KShots, LoadData, RemapLabels, ConsecutiveLabels
 
+
 def mini_imagenet_tasksets(
     train_ways=5,
     train_samples=10,
@@ -10,7 +11,7 @@ def mini_imagenet_tasksets(
     test_samples=10,
     root='~/data',
     **kwargs,
-    ):
+):
     """Tasksets for mini-ImageNet benchmarks."""
     train_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='train')
     valid_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='validation')
@@ -44,4 +45,3 @@ def mini_imagenet_tasksets(
     _datasets = (train_dataset, valid_dataset, test_dataset)
     _transforms = (train_transforms, valid_transforms, test_transforms)
     return _datasets, _transforms
-    

--- a/learn2learn/vision/benchmarks/omniglot_benchmark.py
+++ b/learn2learn/vision/benchmarks/omniglot_benchmark.py
@@ -14,7 +14,7 @@ def omniglot_tasksets(
     test_samples,
     root,
     **kwargs
-    ):
+):
     """
     Benchmark definition for Omniglot.
     """

--- a/learn2learn/vision/benchmarks/omniglot_benchmark.py
+++ b/learn2learn/vision/benchmarks/omniglot_benchmark.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+import random
+import learn2learn as l2l
+
+from torchvision import transforms
+from PIL.Image import LANCZOS
+
+
+def omniglot_tasksets(
+    train_ways,
+    train_samples,
+    test_ways,
+    test_samples,
+    root,
+    **kwargs
+    ):
+    """
+    Benchmark definition for Omniglot.
+    """
+    data_transforms = transforms.Compose([
+        transforms.Resize(28, interpolation=LANCZOS),
+        transforms.ToTensor(),
+        lambda x: 1.0 - x,
+    ])
+    omniglot = l2l.vision.datasets.FullOmniglot(
+        root=root,
+        transform=data_transforms,
+        download=True,
+    )
+    dataset = l2l.data.MetaDataset(omniglot)
+    train_dataset = dataset
+    validation_datatset = dataset
+    test_dataset = dataset
+
+    classes = list(range(1623))
+    random.shuffle(classes)
+    train_transforms = [
+        l2l.data.transforms.FusedNWaysKShots(dataset,
+                                             n=train_ways,
+                                             k=train_samples,
+                                             filter_labels=classes[:1100]),
+        l2l.data.transforms.LoadData(dataset),
+        l2l.data.transforms.RemapLabels(dataset),
+        l2l.data.transforms.ConsecutiveLabels(dataset),
+        l2l.vision.transforms.RandomClassRotation(dataset, [0.0, 90.0, 180.0, 270.0])
+    ]
+    validation_transforms = [
+        l2l.data.transforms.FusedNWaysKShots(dataset,
+                                             n=test_ways,
+                                             k=test_samples,
+                                             filter_labels=classes[1100:1200]),
+        l2l.data.transforms.LoadData(dataset),
+        l2l.data.transforms.RemapLabels(dataset),
+        l2l.data.transforms.ConsecutiveLabels(dataset),
+        l2l.vision.transforms.RandomClassRotation(dataset, [0.0, 90.0, 180.0, 270.0])
+    ]
+    test_transforms = [
+        l2l.data.transforms.FusedNWaysKShots(dataset,
+                                             n=test_ways,
+                                             k=test_samples,
+                                             filter_labels=classes[1200:]),
+        l2l.data.transforms.LoadData(dataset),
+        l2l.data.transforms.RemapLabels(dataset),
+        l2l.data.transforms.ConsecutiveLabels(dataset),
+        l2l.vision.transforms.RandomClassRotation(dataset, [0.0, 90.0, 180.0, 270.0])
+    ]
+
+    _datasets = (train_dataset, validation_datatset, test_dataset)
+    _transforms = (train_transforms, validation_transforms, test_transforms)
+    return _datasets, _transforms

--- a/learn2learn/vision/benchmarks/tiered_imagenet_benchmark.py
+++ b/learn2learn/vision/benchmarks/tiered_imagenet_benchmark.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import learn2learn as l2l
+
 from learn2learn.data.transforms import NWays, KShots, LoadData, RemapLabels, ConsecutiveLabels
 
-def mini_imagenet_tasksets(
+
+def tiered_imagenet_tasksets(
     train_ways=5,
     train_samples=10,
     test_ways=5,
@@ -11,10 +13,13 @@ def mini_imagenet_tasksets(
     root='~/data',
     **kwargs,
     ):
-    """Tasksets for mini-ImageNet benchmarks."""
-    train_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='train')
-    valid_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='validation')
-    test_dataset = l2l.vision.datasets.MiniImagenet(root=root, mode='test')
+    """Tasksets for tiered-ImageNet benchmarks."""
+    train_dataset = l2l.vision.datasets.MiniImagenet(root=root,
+                                                     mode='train')
+    valid_dataset = l2l.vision.datasets.MiniImagenet(root=root,
+                                                     mode='validation')
+    test_dataset = l2l.vision.datasets.MiniImagenet(root=root,
+                                                    mode='test')
     train_dataset = l2l.data.MetaDataset(train_dataset)
     valid_dataset = l2l.data.MetaDataset(valid_dataset)
     test_dataset = l2l.data.MetaDataset(test_dataset)

--- a/learn2learn/vision/benchmarks/tiered_imagenet_benchmark.py
+++ b/learn2learn/vision/benchmarks/tiered_imagenet_benchmark.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import torchvision as tv
 import learn2learn as l2l
 
 from learn2learn.data.transforms import NWays, KShots, LoadData, RemapLabels, ConsecutiveLabels
@@ -14,12 +15,16 @@ def tiered_imagenet_tasksets(
     **kwargs,
 ):
     """Tasksets for tiered-ImageNet benchmarks."""
-    train_dataset = l2l.vision.datasets.MiniImagenet(root=root,
-                                                     mode='train')
-    valid_dataset = l2l.vision.datasets.MiniImagenet(root=root,
-                                                     mode='validation')
-    test_dataset = l2l.vision.datasets.MiniImagenet(root=root,
-                                                    mode='test')
+    data_transform = tv.transforms.ToTensor()
+    train_dataset = l2l.vision.datasets.TieredImagenet(root=root,
+                                                       transform=data_transform,
+                                                       mode='train')
+    valid_dataset = l2l.vision.datasets.TieredImagenet(root=root,
+                                                       transform=data_transform,
+                                                       mode='validation')
+    test_dataset = l2l.vision.datasets.TieredImagenet(root=root,
+                                                      transform=data_transform,
+                                                      mode='test')
     train_dataset = l2l.data.MetaDataset(train_dataset)
     valid_dataset = l2l.data.MetaDataset(valid_dataset)
     test_dataset = l2l.data.MetaDataset(test_dataset)

--- a/learn2learn/vision/benchmarks/tiered_imagenet_benchmark.py
+++ b/learn2learn/vision/benchmarks/tiered_imagenet_benchmark.py
@@ -12,7 +12,7 @@ def tiered_imagenet_tasksets(
     test_samples=10,
     root='~/data',
     **kwargs,
-    ):
+):
     """Tasksets for tiered-ImageNet benchmarks."""
     train_dataset = l2l.vision.datasets.MiniImagenet(root=root,
                                                      mode='train')
@@ -49,4 +49,3 @@ def tiered_imagenet_tasksets(
     _datasets = (train_dataset, valid_dataset, test_dataset)
     _transforms = (train_transforms, valid_transforms, test_transforms)
     return _datasets, _transforms
-    

--- a/learn2learn/vision/benchmarks/tiered_imagenet_benchmark.py
+++ b/learn2learn/vision/benchmarks/tiered_imagenet_benchmark.py
@@ -18,13 +18,16 @@ def tiered_imagenet_tasksets(
     data_transform = tv.transforms.ToTensor()
     train_dataset = l2l.vision.datasets.TieredImagenet(root=root,
                                                        transform=data_transform,
-                                                       mode='train')
+                                                       mode='train',
+                                                       download=True)
     valid_dataset = l2l.vision.datasets.TieredImagenet(root=root,
                                                        transform=data_transform,
-                                                       mode='validation')
+                                                       mode='validation',
+                                                       download=True)
     test_dataset = l2l.vision.datasets.TieredImagenet(root=root,
                                                       transform=data_transform,
-                                                      mode='test')
+                                                      mode='test',
+                                                      download=True)
     train_dataset = l2l.data.MetaDataset(train_dataset)
     valid_dataset = l2l.data.MetaDataset(valid_dataset)
     test_dataset = l2l.data.MetaDataset(test_dataset)

--- a/learn2learn/vision/datasets/cifarfs.py
+++ b/learn2learn/vision/datasets/cifarfs.py
@@ -46,7 +46,12 @@ class CIFARFS(ImageFolder):
 
     """
 
-    def __init__(self, root, mode='train', transform=None, target_transform=None):
+    def __init__(self,
+                 root,
+                 mode='train',
+                 transform=None,
+                 target_transform=None,
+                 download=False):
         self.root = os.path.expanduser(root)
         if not os.path.exists(self.root):
             os.mkdir(self.root)
@@ -56,7 +61,7 @@ class CIFARFS(ImageFolder):
         self.processed_root = os.path.join(self.root, 'cifarfs', 'processed')
         self.raw_path = os.path.join(self.root, 'cifarfs')
 
-        if not self._check_exists():
+        if not self._check_exists() and download:
             self._download()
         if not self._check_processed():
             self._process_zip()

--- a/learn2learn/vision/datasets/fc100.py
+++ b/learn2learn/vision/datasets/fc100.py
@@ -54,7 +54,12 @@ class FC100(data.Dataset):
 
     """
 
-    def __init__(self, root, mode='train', transform=None, target_transform=None):
+    def __init__(self,
+                 root,
+                 mode='train',
+                 transform=None,
+                 target_transform=None,
+                 download=False):
         super(FC100, self).__init__()
         self.root = os.path.expanduser(root)
         os.makedirs(self.root, exist_ok=True)
@@ -65,7 +70,7 @@ class FC100(data.Dataset):
         self.mode = mode
         self._bookkeeping_path = os.path.join(self.root, 'fc100-bookkeeping-' + mode + '.pkl')
 
-        if not self._check_exists():
+        if not self._check_exists() and download:
             self.download()
 
         short_mode = 'val' if mode == 'validation' else mode

--- a/learn2learn/vision/datasets/mini_imagenet.py
+++ b/learn2learn/vision/datasets/mini_imagenet.py
@@ -107,7 +107,6 @@ class MiniImagenet(data.Dataset):
             with open(pickle_file, 'rb') as f:
                 self.data = pickle.load(f)
 
-
         self.x = torch.from_numpy(self.data["image_data"]).permute(0, 3, 1, 2).float()
         self.y = np.ones(len(self.x))
 

--- a/learn2learn/vision/datasets/mini_imagenet.py
+++ b/learn2learn/vision/datasets/mini_imagenet.py
@@ -67,7 +67,12 @@ class MiniImagenet(data.Dataset):
 
     """
 
-    def __init__(self, root, mode='train', transform=None, target_transform=None):
+    def __init__(self,
+                 root,
+                 mode='train',
+                 transform=None,
+                 target_transform=None,
+                 download=False):
         super(MiniImagenet, self).__init__()
         self.root = os.path.expanduser(root)
         if not os.path.exists(self.root):
@@ -85,7 +90,7 @@ class MiniImagenet(data.Dataset):
         else:
             raise ('ValueError', 'Needs to be train, test or validation')
 
-        if not self._check_exists():
+        if not self._check_exists() and download:
             download_pkl(google_drive_file_id, self.root, mode)
 
         pickle_file = os.path.join(self.root, 'mini-imagenet-cache-' + mode + '.pkl')

--- a/learn2learn/vision/datasets/mini_imagenet.py
+++ b/learn2learn/vision/datasets/mini_imagenet.py
@@ -97,13 +97,13 @@ class MiniImagenet(data.Dataset):
         try:
             if not self._check_exists() and download:
                 print('Downloading mini-ImageNet --', mode)
-                download_file(dropbox_file_link, pickle_file)
+                download_pkl(google_drive_file_id, self.root, mode)
             with open(pickle_file, 'rb') as f:
                 self.data = pickle.load(f)
         except pickle.UnpicklingError:
             if not self._check_exists() and download:
                 print('Download failed. Re-trying mini-ImageNet --', mode)
-                download_pkl(google_drive_file_id, self.root, mode)
+                download_file(dropbox_file_link, pickle_file)
             with open(pickle_file, 'rb') as f:
                 self.data = pickle.load(f)
 

--- a/learn2learn/vision/datasets/mini_imagenet.py
+++ b/learn2learn/vision/datasets/mini_imagenet.py
@@ -96,12 +96,14 @@ class MiniImagenet(data.Dataset):
         pickle_file = os.path.join(self.root, 'mini-imagenet-cache-' + mode + '.pkl')
         try:
             if not self._check_exists() and download:
-                download_pkl(google_drive_file_id, self.root, mode)
+                print('Downloading mini-ImageNet --', mode)
+                download_file(dropbox_file_link, pickle_file)
             with open(pickle_file, 'rb') as f:
                 self.data = pickle.load(f)
-        except:
+        except pickle.UnpicklingError:
             if not self._check_exists() and download:
-                download_file(dropbox_file_link, pickle_file)
+                print('Download failed. Re-trying mini-ImageNet --', mode)
+                download_pkl(google_drive_file_id, self.root, mode)
             with open(pickle_file, 'rb') as f:
                 self.data = pickle.load(f)
 
@@ -126,3 +128,8 @@ class MiniImagenet(data.Dataset):
 
     def _check_exists(self):
         return os.path.exists(os.path.join(self.root, 'mini-imagenet-cache-' + self.mode + '.pkl'))
+
+
+if __name__ == '__main__':
+    mi = MiniImagenet(root='./data', download=True)
+    __import__('pdb').set_trace()

--- a/learn2learn/vision/datasets/mini_imagenet.py
+++ b/learn2learn/vision/datasets/mini_imagenet.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 import torch.utils.data as data
 
-from learn2learn.data.utils import download_file_from_google_drive
+from learn2learn.data.utils import download_file_from_google_drive, download_file
 
 
 def download_pkl(google_drive_id, data_root, mode):
@@ -83,19 +83,28 @@ class MiniImagenet(data.Dataset):
         self._bookkeeping_path = os.path.join(self.root, 'mini-imagenet-bookkeeping-' + mode + '.pkl')
         if self.mode == 'test':
             google_drive_file_id = '1wpmY-hmiJUUlRBkO9ZDCXAcIpHEFdOhD'
+            dropbox_file_link = 'https://www.dropbox.com/s/ye9jeb5tyz0x01b/mini-imagenet-cache-test.pkl?dl=1'
         elif self.mode == 'train':
             google_drive_file_id = '1I3itTXpXxGV68olxM5roceUMG8itH9Xj'
+            dropbox_file_link = 'https://www.dropbox.com/s/9g8c6w345s2ek03/mini-imagenet-cache-train.pkl?dl=1'
         elif self.mode == 'validation':
             google_drive_file_id = '1KY5e491bkLFqJDp0-UWou3463Mo8AOco'
+            dropbox_file_link = 'https://www.dropbox.com/s/ip1b7se3gij3r1b/mini-imagenet-cache-validation.pkl?dl=1'
         else:
             raise ('ValueError', 'Needs to be train, test or validation')
 
-        if not self._check_exists() and download:
-            download_pkl(google_drive_file_id, self.root, mode)
-
         pickle_file = os.path.join(self.root, 'mini-imagenet-cache-' + mode + '.pkl')
-        with open(pickle_file, 'rb') as f:
-            self.data = pickle.load(f)
+        try:
+            if not self._check_exists() and download:
+                download_pkl(google_drive_file_id, self.root, mode)
+            with open(pickle_file, 'rb') as f:
+                self.data = pickle.load(f)
+        except:
+            if not self._check_exists() and download:
+                download_file(dropbox_file_link, pickle_file)
+            with open(pickle_file, 'rb') as f:
+                self.data = pickle.load(f)
+
 
         self.x = torch.from_numpy(self.data["image_data"]).permute(0, 3, 1, 2).float()
         self.y = np.ones(len(self.x))

--- a/learn2learn/vision/models.py
+++ b/learn2learn/vision/models.py
@@ -117,7 +117,7 @@ class ConvBase(nn.Sequential):
                           max_pool=max_pool,
                           max_pool_factor=max_pool_factor),
                 ]
-        for l in range(layers - 1):
+        for _ in range(layers - 1):
             core.append(ConvBlock(hidden,
                                   hidden,
                                   kernel_size=(3, 3),

--- a/tests/unit/vision/benchmarks_test.py
+++ b/tests/unit/vision/benchmarks_test.py
@@ -15,10 +15,16 @@ class UtilTests(unittest.TestCase):
     def test_tasksets(self):
         names = l2l.vision.benchmarks.list_tasksets()
         for name in names:
-            tasks = l2l.vision.benchmarks.get_tasksets(name)
-            self.assertTrue(hasattr(tasks, 'train'))
-            self.assertTrue(hasattr(tasks, 'validation'))
-            self.assertTrue(hasattr(tasks, 'test'))
+            tasksets = l2l.vision.benchmarks.get_tasksets(name)
+            self.assertTrue(hasattr(tasksets, 'train'))
+            batch = tasksets.train.sample()
+            self.assertTrue(batch is not None)
+            self.assertTrue(hasattr(tasksets, 'validation'))
+            batch = tasksets.validation.sample()
+            self.assertTrue(batch is not None)
+            self.assertTrue(hasattr(tasksets, 'test'))
+            batch = tasksets.test.sample()
+            self.assertTrue(batch is not None)
 
 
 if __name__ == '__main__':

--- a/tests/unit/vision/benchmarks_test.py
+++ b/tests/unit/vision/benchmarks_test.py
@@ -25,6 +25,7 @@ class UtilTests(unittest.TestCase):
             self.assertTrue(hasattr(tasksets, 'test'))
             batch = tasksets.test.sample()
             self.assertTrue(batch is not None)
+            del tasksets, batch
 
 
 if __name__ == '__main__':

--- a/tests/unit/vision/benchmarks_test.py
+++ b/tests/unit/vision/benchmarks_test.py
@@ -3,6 +3,10 @@
 import unittest
 import learn2learn as l2l
 
+TOO_BIG_TO_TEST = [
+    'tiered-imagenet',
+]
+
 
 class UtilTests(unittest.TestCase):
 
@@ -15,6 +19,8 @@ class UtilTests(unittest.TestCase):
     def test_tasksets(self):
         names = l2l.vision.benchmarks.list_tasksets()
         for name in names:
+            if name in TOO_BIG_TO_TEST:
+                continue
             tasksets = l2l.vision.benchmarks.get_tasksets(name, root='./data')
             self.assertTrue(hasattr(tasksets, 'train'))
             batch = tasksets.train.sample()

--- a/tests/unit/vision/benchmarks_test.py
+++ b/tests/unit/vision/benchmarks_test.py
@@ -15,7 +15,7 @@ class UtilTests(unittest.TestCase):
     def test_tasksets(self):
         names = l2l.vision.benchmarks.list_tasksets()
         for name in names:
-            tasksets = l2l.vision.benchmarks.get_tasksets(name)
+            tasksets = l2l.vision.benchmarks.get_tasksets(name, root='./data')
             self.assertTrue(hasattr(tasksets, 'train'))
             batch = tasksets.train.sample()
             self.assertTrue(batch is not None)

--- a/tests/unit/vision/benchmarks_test.py
+++ b/tests/unit/vision/benchmarks_test.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import unittest
+import learn2learn as l2l
+
+
+class UtilTests(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_tasksets(self):
+        names = l2l.vision.benchmarks.list_tasksets()
+        for name in names:
+            tasks = l2l.vision.benchmarks.get_tasksets(name)
+            self.assertTrue(hasattr(tasks, 'train'))
+            self.assertTrue(hasattr(tasks, 'validation'))
+            self.assertTrue(hasattr(tasks, 'test'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/vision/cifarfs_test.py
+++ b/tests/unit/vision/cifarfs_test.py
@@ -14,7 +14,7 @@ class CIFARFSTests(unittest.TestCase):
         pass
 
     def test_download(self):
-        cifarfs = l2l.vision.datasets.CIFARFS(root='./data')
+        cifarfs = l2l.vision.datasets.CIFARFS(root='./data', download=True)
         path = os.path.join('./data', 'cifarfs', 'processed')
         self.assertTrue(os.path.exists(path))
 

--- a/tests/unit/vision/fc100_test.py
+++ b/tests/unit/vision/fc100_test.py
@@ -15,17 +15,23 @@ class FC100Tests(unittest.TestCase):
 
     def test_download(self):
         root = os.path.expanduser('./data')
-        fc100 = l2l.vision.datasets.FC100(root=root, mode='train')
+        fc100 = l2l.vision.datasets.FC100(root=root,
+                                          mode='train',
+                                          download=True)
         image, label = fc100[12]
         path = os.path.join(root, 'FC100_train.pickle')
         self.assertTrue(os.path.exists(path))
 
-        fc100 = l2l.vision.datasets.FC100(root=root, mode='validation')
+        fc100 = l2l.vision.datasets.FC100(root=root,
+                                          mode='validation',
+                                          download=True)
         image, label = fc100[12]
         path = os.path.join(root, 'FC100_val.pickle')
         self.assertTrue(os.path.exists(path))
 
-        fc100 = l2l.vision.datasets.FC100(root=root, mode='test')
+        fc100 = l2l.vision.datasets.FC100(root=root,
+                                          mode='test',
+                                          download=True)
         image, label = fc100[12]
         path = os.path.join(root, 'FC100_test.pickle')
         self.assertTrue(os.path.exists(path))


### PR DESCRIPTION
### Description

Adds benchmark interface for vision datasets.

This PR adds implementation, documentation, and tests for `l2l.vision.benchmarks`. The new functionality helps remove some boilerplate code when comparing algorithms on standardized benchmarks.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [x] My modifications are documented.

#### Optional

If you make major changes to the core library, please run `make alltests` and copy-paste the content of `alltests.txt` below.

~~~shell
make[1]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
OMP_NUM_THREADS=1 \
MKL_NUM_THREADS=1 \
python -W ignore -m unittest discover -s 'tests' -p '*_test.py' -v
test_final_accuracy (integration.maml_omniglot_test.MAMLOmniglotIntegrationTests) ... ok
test_adaptation (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_allow_nograd (unit.algorithms.maml_test.TestMAMLAlgorithm) ... Traceback (most recent call last):
  File "/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables/learn2learn/algorithms/maml.py", line 186, in adapt
    allow_unused=allow_unused)
  File "/home/seba-1511/anaconda3/lib/python3.7/site-packages/torch/autograd/__init__.py", line 157, in grad
    inputs, allow_unused)
RuntimeError: One of the differentiated Tensors does not require grad
ok
test_allow_unused (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_clone_module (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_graph_connection (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_adaptation (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_clone_module (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_graph_connection (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_meta_lr (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_data_labels_length (unit.data.metadataset_test.TestMetaDataset) ... ok
test_data_labels_values (unit.data.metadataset_test.TestMetaDataset) ... ok
test_data_length (unit.data.metadataset_test.TestMetaDataset) ... ok
test_fails_with_non_torch_dataset (unit.data.metadataset_test.TestMetaDataset) ... ok
test_get_item (unit.data.metadataset_test.TestMetaDataset) ... ok
test_labels_to_indices (unit.data.metadataset_test.TestMetaDataset) ... ok
test_dataloader (unit.data.task_dataset_test.TestTaskDataset) ... Files already downloaded and verified
Files already downloaded and verified
0 Meta Train Accuracy 0.38125000847503543
1 Meta Train Accuracy 0.4625000096857548
2 Meta Train Accuracy 0.4625000115483999
3 Meta Train Accuracy 0.5375000140629709
4 Meta Train Accuracy 0.5125000127591193
learn2learn: Maybe try with allow_nograd=True and/or allow_unused=True ?
Files already downloaded and verified
Files already downloaded and verified
ok
test_infinite_tasks (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_instanciation (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_task_caching (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_task_transforms (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_filter_labels (unit.data.transforms_test.TestTransforms) ... ok
test_k_shots (unit.data.transforms_test.TestTransforms) ... ok
test_load_data (unit.data.transforms_test.TestTransforms) ... ok
test_n_ways (unit.data.transforms_test.TestTransforms) ... ok
test_remap_labels (unit.data.transforms_test.TestTransforms) ... ok
test_clone_module_basics (unit.utils_test.UtilTests) ... ok
test_clone_module_models (unit.utils_test.UtilTests) ... ok
test_clone_module_nomodule (unit.utils_test.UtilTests) ... ok
test_distribution_clone (unit.utils_test.UtilTests) ... ok
test_distribution_detach (unit.utils_test.UtilTests) ... ok
test_module_detach (unit.utils_test.UtilTests) ... ok
test_rnn_clone (unit.utils_test.UtilTests) ... ok
test_tasksets (unit.vision.benchmarks_test.UtilTests) ... ok
test_download (unit.vision.cifarfs_test.CIFARFSTests) ... ok
test_download (unit.vision.fc100_test.FC100Tests) ... ok
test_download (unit.vision.fgvc_aircraft_test.AircraftTests) ... ok
test_download (unit.vision.vgg_flowers_test.FlowersTests) ... ok

----------------------------------------------------------------------
Ran 38 tests in 67.871s

OK
Files already downloaded and verified
Files already downloaded and verified
make lint
make[2]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
pycodestyle learn2learn/ --max-line-length=160
make[2]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
make[1]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
make[1]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
OMP_NUM_THREADS=1 \
MKL_NUM_THREADS=1 \
python -W ignore -m unittest discover -s 'tests' -p '*_test_notravis.py' -v
test_final_accuracy (integration.maml_miniimagenet_test_notravis.MAMLMiniImagenetIntegrationTests) ... ok
test_final_accuracy (integration.protonets_miniimagenet_test_notravis.ProtoNetMiniImageNetIntegrationTests) ... ok
test_download (unit.vision.tiered_imagenet_test_notravis.TieredImagenetTests) ... ok

----------------------------------------------------------------------
Ran 3 tests in 82.389s

OK


Iteration 0
Meta Train Error 0.06558676576241851
Meta Train Accuracy 0.2499999930150807
Meta Valid Error 0.06655425997450948
Meta Valid Accuracy 0.21749999444000423
Meta Test Error 0.06511959538329393
Meta Test Accuracy 0.22999999253079295
epoch 1, train, loss=14.4065 acc=0.0838
epoch 1, val, loss=1.7298 acc=0.2957
batch 200: 28.30(21.33)
make[1]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
~~~
