### PR TITLE
Fixed some examples with cuda usage

### DIFF
--- a/examples/rl/cavia_trpo.py
+++ b/examples/rl/cavia_trpo.py
@@ -157,8 +157,7 @@ def main(
 
         for task_config in tqdm(env.sample_tasks(meta_bsz), leave=False, desc='Data'):  # Samples a new config
             # deepcopy is not working here
-            clone = type(policy)(env.state_size, env.action_size, num_context_params=num_context_params, device=device)
-            clone.load_state_dict(policy.state_dict())
+            clone = l2l.clone_module(policy)
 
             env.set_task(task_config)
             env.reset()
@@ -217,9 +216,7 @@ def main(
         # Line-search
         for ls_step in range(ls_max_steps):
             stepsize = backtrack_factor ** ls_step * meta_lr
-            # deepcopy is not working here
-            clone = type(policy)(env.state_size, env.action_size, num_context_params=num_context_params, device=device)
-            clone.load_state_dict(policy.state_dict())
+            clone = l2l.clone_module(policy)
 
             for p, u in zip(clone.parameters(), step):
                 p.data.add_(-stepsize, u.data)

--- a/examples/rl/cavia_trpo.py
+++ b/examples/rl/cavia_trpo.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+
+"""
+Trains a 2-layer MLP with MAML-TRPO.
+
+Usage:
+
+python examples/rl/maml_trpo.py
+"""
+
+import random
+from copy import deepcopy
+
+import cherry as ch
+import gym
+import numpy as np
+import torch
+from cherry.algorithms import a2c, trpo
+from cherry.models.robotics import LinearValue
+from torch import autograd
+from torch.distributions.kl import kl_divergence
+from torch.nn.utils import parameters_to_vector, vector_to_parameters
+from tqdm import tqdm
+
+import learn2learn as l2l
+from policies import CaviaDiagNormalPolicy
+
+
+def compute_advantages(baseline, tau, gamma, rewards, dones, states, next_states):
+    # Update baseline
+    returns = ch.td.discount(gamma, rewards, dones)
+    baseline.fit(states, returns)
+    values = baseline(states)
+    next_values = baseline(next_states)
+    bootstraps = values * (1.0 - dones) + next_values * dones
+    next_value = torch.zeros(1, device=values.device)
+    return ch.pg.generalized_advantage(tau=tau,
+                                       gamma=gamma,
+                                       rewards=rewards,
+                                       dones=dones,
+                                       values=bootstraps,
+                                       next_value=next_value)
+
+
+def maml_a2c_loss(train_episodes, learner, baseline, gamma, tau):
+    # Update policy and baseline
+    states = train_episodes.state()
+    actions = train_episodes.action()
+    rewards = train_episodes.reward()
+    dones = train_episodes.done()
+    next_states = train_episodes.next_state()
+    log_probs = learner.log_prob(states, actions)
+    advantages = compute_advantages(baseline, tau, gamma, rewards,
+                                    dones, states, next_states)
+    advantages = ch.normalize(advantages).detach()
+    return a2c.policy_loss(log_probs, advantages)
+
+
+def fast_adapt_a2c(clone, train_episodes, adapt_lr, baseline, gamma, tau, first_order=False):
+    second_order = not first_order
+    loss = maml_a2c_loss(train_episodes, clone, baseline, gamma, tau)
+    gradients = autograd.grad(loss,
+                              clone.context_params,
+                              retain_graph=second_order,
+                              create_graph=second_order)
+
+    if not first_order:
+        clone.context_params = clone.context_params - adapt_lr * gradients[0]
+    else:
+        clone.context_params = clone.context_params - adapt_lr * gradients[0].detach()
+
+    return l2l.utils.update_module(clone)
+    # return l2l.algorithms.maml.maml_update(clone, adapt_lr, gradients)
+
+
+def meta_surrogate_loss(iteration_replays, iteration_policies, policy, baseline, tau, gamma, adapt_lr):
+    mean_loss = 0.0
+    mean_kl = 0.0
+    for task_replays, old_policy in tqdm(zip(iteration_replays, iteration_policies),
+                                         total=len(iteration_replays),
+                                         desc='Surrogate Loss',
+                                         leave=False):
+        policy.reset_context()
+        train_replays = task_replays[:-1]
+        valid_episodes = task_replays[-1]
+        new_policy = l2l.clone_module(policy)
+
+        # Fast Adapt
+        for train_episodes in train_replays:
+            new_policy = fast_adapt_a2c(new_policy, train_episodes, adapt_lr,
+                                        baseline, gamma, tau, first_order=False)
+
+        # Useful values
+        states = valid_episodes.state()
+        actions = valid_episodes.action()
+        next_states = valid_episodes.next_state()
+        rewards = valid_episodes.reward()
+        dones = valid_episodes.done()
+
+        # Compute KL
+        old_densities = old_policy.density(states)
+        new_densities = new_policy.density(states)
+        kl = kl_divergence(new_densities, old_densities).mean()
+        mean_kl += kl
+
+        # Compute Surrogate Loss
+        advantages = compute_advantages(baseline, tau, gamma, rewards, dones, states, next_states)
+        advantages = ch.normalize(advantages).detach()
+        old_log_probs = old_densities.log_prob(actions).mean(dim=1, keepdim=True).detach()
+        new_log_probs = new_densities.log_prob(actions).mean(dim=1, keepdim=True)
+        mean_loss += trpo.policy_loss(new_log_probs, old_log_probs, advantages)
+    mean_kl /= len(iteration_replays)
+    mean_loss /= len(iteration_replays)
+    return mean_loss, mean_kl
+
+
+def main(
+        env_name='Particles2D-v1',
+        adapt_lr=0.1,
+        meta_lr=1.0,
+        adapt_steps=1,
+        num_iterations=1000,
+        meta_bsz=20,
+        adapt_bsz=20,
+        tau=1.00,
+        gamma=0.95,
+        seed=42,
+        num_workers=10,
+        cuda=0,
+):
+    cuda = bool(cuda)
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if cuda:
+        torch.cuda.manual_seed(seed)
+
+    def make_env():
+        env = gym.make(env_name)
+        env = ch.envs.ActionSpaceScaler(env)
+        return env
+
+    env = l2l.gym.AsyncVectorEnv([make_env for _ in range(num_workers)])
+    env.seed(seed)
+    env.set_task(env.sample_tasks(1)[0])
+    env = ch.envs.Torch(env)
+    policy = CaviaDiagNormalPolicy(env.state_size, env.action_size)
+    if cuda:
+        policy.to('cuda')
+    baseline = LinearValue(env.state_size, env.action_size)
+
+    for iteration in range(num_iterations):
+        iteration_reward = 0.0
+        iteration_replays = []
+        iteration_policies = []
+
+        for task_config in tqdm(env.sample_tasks(meta_bsz), leave=False, desc='Data'):  # Samples a new config
+            clone = deepcopy(policy)
+            env.set_task(task_config)
+            env.reset()
+            policy.reset_context()
+            task = ch.envs.Runner(env)
+            task_replay = []
+
+            # Fast Adapt
+            for step in range(adapt_steps):
+                train_episodes = task.run(clone, episodes=adapt_bsz)
+                clone = fast_adapt_a2c(clone, train_episodes, adapt_lr,
+                                       baseline, gamma, tau, first_order=True)
+                task_replay.append(train_episodes)
+
+            # Compute Validation Loss
+            valid_episodes = task.run(clone, episodes=adapt_bsz)
+            task_replay.append(valid_episodes)
+            iteration_reward += valid_episodes.reward().sum().item() / adapt_bsz
+            iteration_replays.append(task_replay)
+            iteration_policies.append(clone)
+
+        # Print statistics
+        print('\nIteration', iteration)
+        adaptation_reward = iteration_reward / meta_bsz
+        print('adaptation_reward', adaptation_reward)
+
+        # TRPO meta-optimization
+        backtrack_factor = 0.8
+        ls_max_steps = 15
+        max_kl = 0.01
+        if cuda:
+            policy.to('cuda', non_blocking=True)
+            baseline.to('cuda', non_blocking=True)
+            iteration_replays = [[r.to('cuda', non_blocking=True) for r in task_replays] for task_replays in
+                                 iteration_replays]
+
+        # Compute CG step direction
+        old_loss, old_kl = meta_surrogate_loss(iteration_replays, iteration_policies, policy, baseline, tau, gamma,
+                                               adapt_lr)
+        grad = autograd.grad(old_loss,
+                             policy.parameters(),
+                             retain_graph=True)
+        grad = parameters_to_vector([g.detach() for g in grad])
+        Fvp = trpo.hessian_vector_product(old_kl, policy.parameters())
+        step = trpo.conjugate_gradient(Fvp, grad)
+        shs = 0.5 * torch.dot(step, Fvp(step))
+        lagrange_multiplier = torch.sqrt(shs / max_kl)
+        step = step / lagrange_multiplier
+        step_ = [torch.zeros_like(p.data) for p in policy.parameters()]
+        vector_to_parameters(step, step_)
+        step = step_
+        del old_kl, Fvp, grad
+        old_loss.detach_()
+
+        # Line-search
+        for ls_step in range(ls_max_steps):
+            stepsize = backtrack_factor ** ls_step * meta_lr
+            clone = deepcopy(policy)
+            for p, u in zip(clone.parameters(), step):
+                p.data.add_(-stepsize, u.data)
+            new_loss, kl = meta_surrogate_loss(iteration_replays, iteration_policies, clone, baseline, tau, gamma,
+                                               adapt_lr)
+            if new_loss < old_loss and kl < max_kl:
+                for p, u in zip(policy.parameters(), step):
+                    p.data.add_(-stepsize, u.data)
+                break
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/rl/cavia_trpo.py
+++ b/examples/rl/cavia_trpo.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 
 """
-Trains a 2-layer MLP with MAML-TRPO.
+Trains a 2-layer MLP with CAVIA-TRPO.
 
 Usage:
 
-python examples/rl/maml_trpo.py
+python examples/rl/cavia_trpo.py
 """
 
 import random
-from copy import deepcopy
 
 import cherry as ch
 import gym
@@ -127,13 +126,17 @@ def main(
         seed=42,
         num_workers=10,
         cuda=0,
+        num_context_params=2
 ):
     cuda = bool(cuda)
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
+    device_name = 'cpu'
     if cuda:
         torch.cuda.manual_seed(seed)
+        device_name = 'cuda'
+    device = torch.device(device_name)
 
     def make_env():
         env = gym.make(env_name)
@@ -144,9 +147,7 @@ def main(
     env.seed(seed)
     env.set_task(env.sample_tasks(1)[0])
     env = ch.envs.Torch(env)
-    policy = CaviaDiagNormalPolicy(env.state_size, env.action_size)
-    if cuda:
-        policy.to('cuda')
+    policy = CaviaDiagNormalPolicy(env.state_size, env.action_size, num_context_params=num_context_params, device=device)
     baseline = LinearValue(env.state_size, env.action_size)
 
     for iteration in range(num_iterations):
@@ -155,7 +156,10 @@ def main(
         iteration_policies = []
 
         for task_config in tqdm(env.sample_tasks(meta_bsz), leave=False, desc='Data'):  # Samples a new config
-            clone = deepcopy(policy)
+            # deepcopy is not working here
+            clone = type(policy)(env.state_size, env.action_size, num_context_params=num_context_params, device=device)
+            clone.load_state_dict(policy.state_dict())
+
             env.set_task(task_config)
             env.reset()
             policy.reset_context()
@@ -165,6 +169,8 @@ def main(
             # Fast Adapt
             for step in range(adapt_steps):
                 train_episodes = task.run(clone, episodes=adapt_bsz)
+                if cuda:
+                    train_episodes = train_episodes.to(device, non_blocking=True)
                 clone = fast_adapt_a2c(clone, train_episodes, adapt_lr,
                                        baseline, gamma, tau, first_order=True)
                 task_replay.append(train_episodes)
@@ -186,9 +192,8 @@ def main(
         ls_max_steps = 15
         max_kl = 0.01
         if cuda:
-            policy.to('cuda', non_blocking=True)
-            baseline.to('cuda', non_blocking=True)
-            iteration_replays = [[r.to('cuda', non_blocking=True) for r in task_replays] for task_replays in
+            baseline = baseline.to(device, non_blocking=True)
+            iteration_replays = [[r.to(device, non_blocking=True) for r in task_replays] for task_replays in
                                  iteration_replays]
 
         # Compute CG step direction
@@ -212,7 +217,10 @@ def main(
         # Line-search
         for ls_step in range(ls_max_steps):
             stepsize = backtrack_factor ** ls_step * meta_lr
-            clone = deepcopy(policy)
+            # deepcopy is not working here
+            clone = type(policy)(env.state_size, env.action_size, num_context_params=num_context_params, device=device)
+            clone.load_state_dict(policy.state_dict())
+
             for p, u in zip(clone.parameters(), step):
                 p.data.add_(-stepsize, u.data)
             new_loss, kl = meta_surrogate_loss(iteration_replays, iteration_policies, clone, baseline, tau, gamma,

--- a/examples/rl/maml_trpo_metaworld.py
+++ b/examples/rl/maml_trpo_metaworld.py
@@ -239,10 +239,15 @@ def main(
                 break
 
     # Evaluate on a set of unseen tasks
-    evaluate(benchmark, policy, baseline, adapt_lr, gamma, tau, num_workers, seed, device=device)
+    evaluate(benchmark, policy, baseline, adapt_lr, gamma, tau, num_workers, seed, cuda)
 
 
-def evaluate(benchmark, policy, baseline, adapt_lr, gamma, tau, n_workers, seed, device='cpu'):
+def evaluate(benchmark, policy, baseline, adapt_lr, gamma, tau, n_workers, seed, cuda):
+    device_name = 'cpu'
+    if cuda:
+        device_name = 'cuda'
+    device = torch.device(device_name)
+
     # Parameters
     adapt_steps = 3
     adapt_bsz = 10
@@ -262,7 +267,7 @@ def evaluate(benchmark, policy, baseline, adapt_lr, gamma, tau, n_workers, seed,
         # Adapt
         for step in range(adapt_steps):
             adapt_episodes = task.run(clone, episodes=adapt_bsz)
-            if device not in 'cpu':
+            if cuda:
                 adapt_episodes = adapt_episodes.to(device, non_blocking=True)
             clone = fast_adapt_a2c(clone, adapt_episodes, adapt_lr, baseline, gamma, tau, first_order=True)
 

--- a/examples/rl/maml_trpo_metaworld.py
+++ b/examples/rl/maml_trpo_metaworld.py
@@ -239,10 +239,10 @@ def main(
                 break
 
     # Evaluate on a set of unseen tasks
-    evaluate(benchmark, policy, baseline, adapt_lr, gamma, tau, num_workers, seed)
+    evaluate(benchmark, policy, baseline, adapt_lr, gamma, tau, num_workers, seed, device=device)
 
 
-def evaluate(benchmark, policy, baseline, adapt_lr, gamma, tau, n_workers, seed):
+def evaluate(benchmark, policy, baseline, adapt_lr, gamma, tau, n_workers, seed, device='cpu'):
     # Parameters
     adapt_steps = 3
     adapt_bsz = 10
@@ -262,6 +262,8 @@ def evaluate(benchmark, policy, baseline, adapt_lr, gamma, tau, n_workers, seed)
         # Adapt
         for step in range(adapt_steps):
             adapt_episodes = task.run(clone, episodes=adapt_bsz)
+            if device not in 'cpu':
+                adapt_episodes = adapt_episodes.to(device, non_blocking=True)
             clone = fast_adapt_a2c(clone, adapt_episodes, adapt_lr, baseline, gamma, tau, first_order=True)
 
         eval_episodes = task.run(clone, episodes=adapt_bsz)


### PR DESCRIPTION
### Description

If example maml_trpo.py is run with cuda following error occurs:
```bash
Traceback (most recent call last):
  File "maml_trpo.py", line 218, in <module>
    main(cuda=1)
  File "maml_trpo.py", line 158, in main
    train_episodes = task.run(clone, episodes=adapt_bsz)
  File "/home/jan/workspace_python/maml-torch/cherry/cherry/envs/runner_wrapper.py", line 117, in run
    action = get_action(self._current_state)
  File "/home/jan/anaconda3/envs/pytorch/lib/python3.8/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/jan/workspace_python/forks/learn2learn/examples/rl/policies.py", line 95, in forward
    density = self.density(state)
  File "/home/jan/workspace_python/forks/learn2learn/examples/rl/policies.py", line 86, in density
    loc = self.mean(state)
  File "/home/jan/anaconda3/envs/pytorch/lib/python3.8/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/jan/anaconda3/envs/pytorch/lib/python3.8/site-packages/torch/nn/modules/container.py", line 100, in forward
    input = module(input)
  File "/home/jan/anaconda3/envs/pytorch/lib/python3.8/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/jan/anaconda3/envs/pytorch/lib/python3.8/site-packages/torch/nn/modules/linear.py", line 87, in forward
    return F.linear(input, self.weight, self.bias)
  File "/home/jan/anaconda3/envs/pytorch/lib/python3.8/site-packages/torch/nn/functional.py", line 1610, in linear
    ret = torch.addmm(bias, input, weight.t())
RuntimeError: Expected object of device type cuda but got device type cpu for argument #2 'mat1' in call to _th_addmm
```

* I fixed it by using copy for the state in density function.
* I also fixed the cavia_trpo.py and maml_trpo_metaworld.py example.

### Contribution Checklist

- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [ ] My modifications are documented.

