### PR TITLE
Update meta_dataset.pyx

### DIFF
--- a/learn2learn/data/meta_dataset.pyx
+++ b/learn2learn/data/meta_dataset.pyx
@@ -79,19 +79,15 @@ class MetaDataset(Dataset):
 
         # Bootstrap from arguments
         if labels_to_indices is not None:
-            self.indices_to_labels = {
+            indices_to_labels = {
                 idx: label
                 for label, indices in labels_to_indices.items()
                 for idx in indices
             }
-            self.labels_to_indices = labels_to_indices
-            self.labels = labels_to_indices.keys()
         elif indices_to_labels is not None:
-            self.labels_to_indices = defaultdict(list)
+            labels_to_indices = defaultdict(list)
             for idx, label in indices_to_labels.items():
-                self.labels_to_indices[label].append(idx)
-            self.indices_to_labels = indices_to_labels
-            self.labels = labels_to_indices.keys()
+                labels_to_indices[label].append(idx)
         else:  # Create from scratch
             labels_to_indices = defaultdict(list)
             indices_to_labels = defaultdict(int)


### PR DESCRIPTION
### Description

Fix an issue causes `MetaDataset.indices_to_labels` or `MetaDataset.labels_to_indices` is None.
This issue happens when constructing `MetaDataset `with only `indices_to_labels `or `labels_to_indices `given. 
Such as follwing:
```
dataset = SomeDataset(...)
indices_to_labels = dataset.indices_to_labels # The dict is kindly generated by the dataset when parsing list file.
meta_dataset = l2l.data.MetaDataset(dataset, indices_to_labels=indices_to_labels)

# Here, meta_dataset.labels_to_indecies is None

train_transforms = [
        NWays(meta_dataset , args.train_way),
        KShots(meta_dataset , args.train_query + args.shot),
        LoadData(meta_dataset ),
        RemapLabels(meta_dataset ),
    ]
# Errors
```

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [ ] My modifications are tested.
- [ ] My modifications are documented.

Only very limited tests are performed.
