### PR TITLE
Fix clone_module to suppress "Accessing .grad" warning.

### DIFF
--- a/learn2learn/data/utils.py
+++ b/learn2learn/data/utils.py
@@ -2,12 +2,13 @@
 
 import requests
 import tqdm
-import shutil
 
 CHUNK_SIZE = 1 * 1024 * 1024
 
 
 def download_file(source, destination, size=None):
+    if size is None:
+        size = 0
     req = requests.get(source, stream=True)
     with open(destination, 'wb') as archive:
         for chunk in tqdm.tqdm(

--- a/learn2learn/utils.py
+++ b/learn2learn/utils.py
@@ -146,7 +146,8 @@ def clone_module(module, memo=None):
     # Finally, rebuild the flattened parameters for RNNs
     # See this issue for more details:
     # https://github.com/learnables/learn2learn/issues/139
-    clone = clone._apply(lambda x: x)
+    if hasattr(clone, 'flatten_parameters'):
+        clone = clone._apply(lambda x: x)
     return clone
 
 
@@ -301,5 +302,6 @@ def update_module(module, updates=None, memo=None):
     # Finally, rebuild the flattened parameters for RNNs
     # See this issue for more details:
     # https://github.com/learnables/learn2learn/issues/139
-    module._apply(lambda x: x)
+    if hasattr(module, 'flatten_parameters'):
+        module._apply(lambda x: x)
     return module


### PR DESCRIPTION
### Description

Fixes #188 

The warning is triggered by calling `._apply()` for non RNN modules. 

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [x] My modifications are documented.
