### PR TITLE
Adds FilteredMetaDataset and fixes length of UnionMetaDataset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* `UnionMetaDatasest` to getthe union of multiple MetaDatasets.
+* `FilteredMetaDatasest` filter the classes used to sample tasks.
+* `UnionMetaDatasest` to get the union of multiple MetaDatasets.
 * Alias `MiniImageNetCNN` to `CNN4` and add `embedding_size` argument.
 * Optional data augmentation schemes for vision benchmarks.
 * `l2l.vision.models.ResNet12`

--- a/docs/pydocmd.yml
+++ b/docs/pydocmd.yml
@@ -15,6 +15,7 @@ generate:
       - learn2learn.data:
           - learn2learn.data.MetaDataset
           - learn2learn.data.UnionMetaDataset
+          - learn2learn.data.FilteredMetaDataset
           - learn2learn.data.TaskDataset
           - learn2learn.data.transforms:
               - learn2learn.data.transforms.LoadData

--- a/learn2learn/data/__init__.py
+++ b/learn2learn/data/__init__.py
@@ -5,5 +5,5 @@ A set of utilities for data & tasks loading, preprocessing, and sampling.
 """
 
 from . import transforms
-from .meta_dataset import MetaDataset, UnionMetaDataset
+from .meta_dataset import MetaDataset, UnionMetaDataset, FilteredMetaDataset
 from .task_dataset import TaskDataset, DataDescription

--- a/learn2learn/data/meta_dataset.pyx
+++ b/learn2learn/data/meta_dataset.pyx
@@ -191,4 +191,4 @@ class UnionMetaDataset(MetaDataset):
             ds_count += len(dataset)
 
     def __len__(self):
-        return len(self.labels_to_indices)
+        return len(self.indices_to_labels)

--- a/tests/unit/data/metadataset_test.py
+++ b/tests/unit/data/metadataset_test.py
@@ -103,6 +103,13 @@ class TestMetaDataset(TestCase):
             classes = datasets[1].labels
             filtered = l2l.data.FilteredMetaDataset(union, classes)
             self.assertEqual(len(filtered.labels), len(datasets[1].labels))
+            self.assertEqual(len(filtered), len(datasets[1]))
+            for label in filtered.labels:
+                self.assertTrue(label in datasets[1].labels)
+                self.assertEqual(
+                    len(filtered.labels_to_indices[label]),
+                    len(datasets[1].labels_to_indices[label])
+                )
 
 
 if __name__ == '__main__':

--- a/tests/unit/data/metadataset_test.py
+++ b/tests/unit/data/metadataset_test.py
@@ -88,6 +88,22 @@ class TestMetaDataset(TestCase):
             # self.assertTrue(item[1] == ref[1])  # Would fail, because labels are remapped.
             self.assertTrue(np.linalg.norm(np.array(item[0]) - np.array(ref[0])) <= 1e-6)
 
+    def test_filtered_metadataset(self):
+        for ds_class in [
+            l2l.vision.datasets.FC100,
+            l2l.vision.datasets.CIFARFS,
+        ]:
+            datasets = [
+                ds_class('~/data', mode='train', download=True),
+                ds_class('~/data', mode='validation', download=True),
+                ds_class('~/data', mode='test', download=True),
+            ]
+            datasets = [l2l.data.MetaDataset(ds) for ds in datasets]
+            union = l2l.data.UnionMetaDataset(datasets)
+            classes = datasets[1].labels
+            filtered = l2l.data.FilteredMetaDataset(union, classes)
+            self.assertEqual(len(filtered.labels), len(datasets[1].labels))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/data/metadataset_test.py
+++ b/tests/unit/data/metadataset_test.py
@@ -76,6 +76,7 @@ class TestMetaDataset(TestCase):
             ]
             datasets = [l2l.data.MetaDataset(ds) for ds in datasets]
             union = l2l.data.UnionMetaDataset(datasets)
+            self.assertEqual(len(union), sum([len(ds) for ds in datasets]))
             self.assertTrue(len(union.labels) == sum([len(ds.labels) for ds in datasets]))
             self.assertTrue(len(union.indices_to_labels) == sum([len(ds.indices_to_labels) for ds in datasets]))
             ref = datasets[1][23]


### PR DESCRIPTION
### Description

Adds FilteredMetaDataset and fixes length of UnionMetaDataset.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [x] My modifications are documented.

#### Optional

If you make major changes to the core library, please run `make alltests` and copy-paste the content of `alltests.txt` below.

~~~shell
make[1]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
OMP_NUM_THREADS=1 \
MKL_NUM_THREADS=1 \
python -W ignore -m unittest discover -s 'tests' -p '*_test.py' -v
test_final_accuracy (integration.maml_omniglot_test.MAMLOmniglotIntegrationTests) ... ok
test_adaptation (unit.algorithms.gbml_test.TestGBMLgorithm) ... ok
test_allow_nograd (unit.algorithms.gbml_test.TestGBMLgorithm) ... Traceback (most recent call last):
  File "/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables/learn2learn/optim/parameter_update.py", line 124, in forward
    allow_unused=allow_unused,
  File "/home/seba-1511/anaconda3/lib/python3.7/site-packages/torch/autograd/__init__.py", line 157, in grad
    inputs, allow_unused)
RuntimeError: One of the differentiated Tensors does not require grad
ok
test_allow_unused (unit.algorithms.gbml_test.TestGBMLgorithm) ... ok
test_clone_module (unit.algorithms.gbml_test.TestGBMLgorithm) ... ok
test_graph_connection (unit.algorithms.gbml_test.TestGBMLgorithm) ... ok
test_adaptation (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_allow_nograd (unit.algorithms.maml_test.TestMAMLAlgorithm) ... Traceback (most recent call last):
  File "/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables/learn2learn/algorithms/maml.py", line 163, in adapt
    allow_unused=allow_unused)
  File "/home/seba-1511/anaconda3/lib/python3.7/site-packages/torch/autograd/__init__.py", line 157, in grad
    inputs, allow_unused)
RuntimeError: One of the differentiated Tensors does not require grad
ok
test_allow_unused (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_clone_module (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_graph_connection (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_module_shared_params (unit.algorithms.maml_test.TestMAMLAlgorithm) ... ok
test_adaptation (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_clone_module (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_graph_connection (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_meta_lr (unit.algorithms.metasgd_test.TestMetaSGDAlgorithm) ... ok
test_data_labels_length (unit.data.metadataset_test.TestMetaDataset) ... ok
test_data_labels_values (unit.data.metadataset_test.TestMetaDataset) ... ok
test_data_length (unit.data.metadataset_test.TestMetaDataset) ... ok
test_fails_with_non_torch_dataset (unit.data.metadataset_test.TestMetaDataset) ... ok
test_filtered_metadataset (unit.data.metadataset_test.TestMetaDataset) ... ok
test_get_item (unit.data.metadataset_test.TestMetaDataset) ... ok
test_labels_to_indices (unit.data.metadataset_test.TestMetaDataset) ... ok
test_union_metadataset (unit.data.metadataset_test.TestMetaDataset) ... ok
test_dataloader (unit.data.task_dataset_test.TestTaskDataset) ... Files already downloaded and verified
Files already downloaded and verified
0 Meta Train Accuracy 0.38125000847503543
1 Meta Train Accuracy 0.4625000096857548
2 Meta Train Accuracy 0.4625000115483999
3 Meta Train Accuracy 0.5375000140629709
4 Meta Train Accuracy 0.5125000127591193
learn2learn: Maybe try with allow_nograd=True and/orallow_unused=True ?
learn2learn: Maybe try with allow_nograd=True and/or allow_unused=True ?
Files already downloaded and verified
Files already downloaded and verified
ok
test_infinite_tasks (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_instanciation (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_task_caching (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_task_transforms (unit.data.task_dataset_test.TestTaskDataset) ... ok
test_filter_labels (unit.data.transforms_test.TestTransforms) ... ok
test_k_shots (unit.data.transforms_test.TestTransforms) ... ok
test_load_data (unit.data.transforms_test.TestTransforms) ... ok
test_n_ways (unit.data.transforms_test.TestTransforms) ... ok
test_remap_labels (unit.data.transforms_test.TestTransforms) ... ok
test_clone_module_basics (unit.utils_test.UtilTests) ... ok
test_clone_module_models (unit.utils_test.UtilTests) ... ok
test_clone_module_nomodule (unit.utils_test.UtilTests) ... ok
test_distribution_clone (unit.utils_test.UtilTests) ... ok
test_distribution_detach (unit.utils_test.UtilTests) ... ok
test_module_clone_shared_params (unit.utils_test.UtilTests) ... ok
test_module_detach (unit.utils_test.UtilTests) ... ok
test_module_update_shared_params (unit.utils_test.UtilTests) ... ok
test_rnn_clone (unit.utils_test.UtilTests) ... ok

----------------------------------------------------------------------
Ran 43 tests in 26.400s

OK
make lint
make[2]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
pycodestyle learn2learn/ --max-line-length=160
make[2]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
make[1]: Leaving directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
make[1]: Entering directory '/media/seba-1511/OCZ/Dropbox/Dev/l2l_learnables'
OMP_NUM_THREADS=1 \
MKL_NUM_THREADS=1 \
python -W ignore -m unittest discover -s 'tests' -p '*_test_notravis.py' -v
test_final_accuracy (integration.maml_miniimagenet_test_notravis.MAMLMiniImagenetIntegrationTests) ... ok
test_final_accuracy (integration.protonets_miniimagenet_test_notravis.ProtoNetMiniImageNetIntegrationTests) ... ok
test_tasksets (unit.vision.benchmarks_test_notravis.UtilTests) ... ok
test_download (unit.vision.cifarfs_test_notravis.CIFARFSTests) ... ok
test_download (unit.vision.cu_birds200_test_notravis.BirdsTests) ... ok
test_download (unit.vision.describable_textures_test_notravis.DTDTests) ... ok
test_download (unit.vision.fc100_test_notravis.FC100Tests) ... ok
test_download (unit.vision.fgvc_aircraft_test_notravis.AircraftTests) ... ok
test_download (unit.vision.tiered_imagenet_test_notravis.TieredImagenetTests) ... ok
test_download (unit.vision.vgg_flowers_test_notravis.FlowersTests) ... ok

----------------------------------------------------------------------
Ran 10 tests in 90.927s

OK
~~~
