### PR TITLE
Fix double error normalisation in maml example

### DIFF
--- a/examples/vision/maml_miniimagenet.py
+++ b/examples/vision/maml_miniimagenet.py
@@ -43,13 +43,11 @@ def fast_adapt(batch, learner, loss, adaptation_steps, shots, ways, device):
     # Adapt the model
     for step in range(adaptation_steps):
         adaptation_error = loss(learner(adaptation_data), adaptation_labels)
-        adaptation_error /= len(adaptation_data)
         learner.adapt(adaptation_error)
 
     # Evaluate the adapted model
     predictions = learner(evaluation_data)
     evaluation_error = loss(predictions, evaluation_labels)
-    evaluation_error /= len(evaluation_data)
     evaluation_accuracy = accuracy(predictions, evaluation_labels)
     return evaluation_error, evaluation_accuracy
 


### PR DESCRIPTION
### Description

Fixes #190 

In the current example of MAML applied to mini-imagenet the averaged loss is averaged twice.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [x] My modifications are documented.
