### PR TITLE
Fix omniglot double normalization issue

### DIFF
--- a/examples/vision/maml_omniglot.py
+++ b/examples/vision/maml_omniglot.py
@@ -36,13 +36,11 @@ def fast_adapt(batch, learner, loss, adaptation_steps, shots, ways, device):
     # Adapt the model
     for step in range(adaptation_steps):
         train_error = loss(learner(adaptation_data), adaptation_labels)
-        train_error /= len(adaptation_data)
         learner.adapt(train_error)
 
     # Evaluate the adapted model
     predictions = learner(evaluation_data)
     valid_error = loss(predictions, evaluation_labels)
-    valid_error /= len(evaluation_data)
     valid_accuracy = accuracy(predictions, evaluation_labels)
     return valid_error, valid_accuracy
 


### PR DESCRIPTION
Similar to #196

### Description

Fixes an issue similar to #190 for the OmniGlot dataset.

The loss function already uses `mean` as it's aggregation, therefore the computed loss should not be re-normalised.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [ ] My modifications are documented.