### PR TITLE
Add TADAM's version of ResNet12.

### DIFF
--- a/.github/workflows/python_unittest.yaml
+++ b/.github/workflows/python_unittest.yaml
@@ -10,7 +10,7 @@ jobs:
             matrix:
                 os: [ubuntu-18.04, ubuntu-latest, macos-latest]
                 python: ['3.7', '3.8']
-                pytorch: ['1.4.0', '1.5.0', '1.6.0', '1.7.0']
+                pytorch: ['1.4.0', '1.5.0', '1.6.0', '1.7.0', '1.8.0', '1.9.1']
                 include:
                     - pytorch: '1.4.0'
                       torchvision: '0.5.0'
@@ -20,6 +20,10 @@ jobs:
                       torchvision: '0.7.0'
                     - pytorch: '1.7.0'
                       torchvision: '0.8.0'
+                    - pytorch: '1.8.0'
+                      torchvision: '0.9.0'
+                    - pytorch: '1.9.0'
+                      torchvision: '0.10.0'
                 exclude:
                     - pytorch: '1.3.0'
                       python: '3.8'

--- a/.github/workflows/python_unittest.yaml
+++ b/.github/workflows/python_unittest.yaml
@@ -10,10 +10,8 @@ jobs:
             matrix:
                 os: [ubuntu-18.04, ubuntu-latest, macos-latest]
                 python: ['3.7', '3.8']
-                pytorch: ['1.3.0', '1.4.0', '1.5.0', '1.6.0', '1.7.0']
-                include: 
-                    - pytorch: '1.3.0'
-                      torchvision: '0.4.1'
+                pytorch: ['1.4.0', '1.5.0', '1.6.0', '1.7.0']
+                include:
                     - pytorch: '1.4.0'
                       torchvision: '0.5.0'
                     - pytorch: '1.5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * PyTorch Lightning interface to MAML, ANIL, ProtoNet, MetaOptNet.
 * Automatic batcher for Lighting: `l2l.data.EpisodicBatcher`.
 * `l2l.nn.PrototypicalClassifier` and `l2l.nn.SVMClassifier`.
-* Separate modules for `CNN4Backbone` and `ResNet12Backbone`.
+* Add `l2l.vision.models.WRN28`.
+* Separate modules for `CNN4Backbone`, `ResNet12Backbone`, `WRN28Backbones` w/ pretrained weights.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * PyTorch Lightning interface to MAML, ANIL, ProtoNet, MetaOptNet.
 * Automatic batcher for Lighting: `l2l.data.EpisodicBatcher`.
 * `l2l.nn.PrototypicalClassifier` and `l2l.nn.SVMClassifier`.
+* Separate modules for `CNN4Backbone` and `ResNet12Backbone`.
 
 ### Changed
 

--- a/docs/pydocmd.yml
+++ b/docs/pydocmd.yml
@@ -86,6 +86,7 @@ generate:
               - learn2learn.vision.datasets.CIFARFS
               - learn2learn.vision.datasets.VGGFlower102
               - learn2learn.vision.datasets.FGVCAircraft
+              - learn2learn.vision.datasets.FGVCFungi
               - learn2learn.vision.datasets.DescribableTextures
               - learn2learn.vision.datasets.CUBirds200
               - learn2learn.vision.datasets.Quickdraw

--- a/docs/pydocmd.yml
+++ b/docs/pydocmd.yml
@@ -76,6 +76,8 @@ generate:
               - learn2learn.vision.models.OmniglotCNN
               - learn2learn.vision.models.CNN4
               - learn2learn.vision.models.ResNet12
+              - learn2learn.vision.models.WRN28
+              - learn2learn.vision.models.get_pretrained_backbone
           - learn2learn.vision.datasets:
               - learn2learn.vision.datasets.FullOmniglot
               - learn2learn.vision.datasets.MiniImagenet

--- a/learn2learn/algorithms/lightning/lightning_episodic_module.py
+++ b/learn2learn/algorithms/lightning/lightning_episodic_module.py
@@ -3,12 +3,16 @@
 """
 """
 
-from learn2learn.utils import _ImportRaiser
-
 try:
     from pytorch_lightning import LightningModule
 except ImportError:
-    LightningModule = _ImportRaiser('pytorch_lightning', 'pip install pytorch_lightning')
+    from learn2learn.utils import _ImportRaiser
+
+    class LightningRaiser(_ImportRaiser):
+
+        def __init__(self, *args, **kwargs):
+            self.name = 'pytorch_lightning'
+            self.command = 'pip install pytorch_lightning==1.0.2'
 
 from torch import optim
 from argparse import ArgumentParser

--- a/learn2learn/algorithms/lightning/lightning_episodic_module.py
+++ b/learn2learn/algorithms/lightning/lightning_episodic_module.py
@@ -3,13 +3,18 @@
 """
 """
 
-import pytorch_lightning as pl
+from learn2learn.utils import _ImportRaiser
+
+try:
+    from pytorch_lightning import LightningModule
+except ImportError:
+    LightningModule = _ImportRaiser('pytorch_lightning', 'pip install pytorch_lightning')
 
 from torch import optim
 from argparse import ArgumentParser
 
 
-class LightningEpisodicModule(pl.LightningModule):
+class LightningEpisodicModule(LightningModule):
     """docstring for LightningEpisodicModule"""
 
     train_shots = 1

--- a/learn2learn/algorithms/lightning/lightning_episodic_module.py
+++ b/learn2learn/algorithms/lightning/lightning_episodic_module.py
@@ -14,6 +14,8 @@ except ImportError:
             self.name = 'pytorch_lightning'
             self.command = 'pip install pytorch_lightning==1.0.2'
 
+    LightningModule = LightningRaiser
+
 from torch import optim
 from argparse import ArgumentParser
 

--- a/learn2learn/nn/misc.py
+++ b/learn2learn/nn/misc.py
@@ -79,7 +79,7 @@ class Scale(torch.nn.Module):
         super(Scale, self).__init__()
         if isinstance(shape, int):
             shape = (shape, )
-        alpha = torch.ones(**shape)
+        alpha = torch.ones(**shape) * alpha
         self.alpha = torch.nn.Parameter(alpha)
 
     def forward(self, x):

--- a/learn2learn/vision/models/__init__.py
+++ b/learn2learn/vision/models/__init__.py
@@ -14,6 +14,11 @@ def forward(self, x):
 ~~~
 """
 
+import os
+import torch
+
+from learn2learn.data.utils import download_file
+
 from .cnn4 import (
     fc_init_,
     maml_init_,
@@ -27,3 +32,80 @@ from .cnn4 import (
 )
 from .resnet12 import ResNet12, ResNet12Backbone
 from .wrn28 import WRN28, WRN28Backbone
+
+__all__ = [
+    'get_pretrained_backbone',
+    'fc_init_',
+    'maml_init_',
+    'ConvBlock',
+    'ConvBase',
+    'OmniglotFC',
+    'OmniglotCNN',
+    'MiniImagenetCNN',
+    'CNN4',
+    'CNN4Backbone',
+    'ResNet12',
+    'ResNet12Backbone',
+    'WRN28',
+    'WRN28Backbone',
+]
+
+_BACKBONE_URLS = {
+    'mini-imagenet': {
+        'cnn4': 'https://zenodo.org/record/5204557/files/MiniImageNet-CNN4.pth',
+        'resnet12': 'https://zenodo.org/record/5204557/files/MiniImageNet-ResNet12.pth',
+        'wrn28': 'https://zenodo.org/record/5204557/files/MiniImageNet-WRN28.pth',
+    },
+    'tiered-imagenet': {
+        'resnet12': 'https://zenodo.org/record/5204557/files/TieredImageNet-ResNet12.pth',
+        'wrn28': 'https://zenodo.org/record/5204557/files/TieredImageNet-WRN28.pth',
+    },
+}
+
+
+def get_pretrained_backbone(model, dataset, root, download=False):
+    """
+    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/vision/models/__init__.py)
+
+    **Description**
+
+    Returns pretrained backbone for a benchmark dataset.
+
+    The returned object is a torch.nn.Module instance.
+
+    **Arguments**
+
+    * **model** (str) - The name of the model (`cnn4`, `resnet12`, or `wrn28`)
+    * **dataset** (str) - The name of the benchmark dataset (`mini-imagenet` or `tiered-imagenet`).
+    * **root** (str) - Location of the pretrained weights.
+    * **download** (bool) - Download the pretrained weights if not available?
+
+    **Example**
+    ~~~python
+    backbone = l2l.vision.models.get_pretrained_backbone(
+        model='omniglot',
+        dataset='mini-imagenet',
+        root='~/.data',
+        download=True,
+    )
+    ~~~
+    """
+    root = os.path.expanduser(root)
+    destination_dir = os.path.join(root, 'pretrained_models', dataset)
+    destination = os.path.join(destination_dir, model + '.pth')
+    source = _BACKBONE_URLS[dataset][model]
+    if not os.path.exists(destination) and download:
+        print(f'Downloading {model} weights for {dataset}.')
+        os.makedirs(destination_dir, exist_ok=True)
+        download_file(source, destination)
+
+    if model == 'cnn4':
+        pretrained = CNN4Backbone(channels=3, max_pool=True)
+    elif model == 'resnet12':
+        pretrained = ResNet12Backbone(avg_pool=False)
+    elif model == 'wrn28':
+        pretrained = WRN28Backbone()
+
+    weights = torch.load(destination)
+    pretrained.load_state_dict(weights)
+    return pretrained

--- a/learn2learn/vision/models/__init__.py
+++ b/learn2learn/vision/models/__init__.py
@@ -26,3 +26,4 @@ from .cnn4 import (
     CNN4Backbone,
 )
 from .resnet12 import ResNet12, ResNet12Backbone
+from .wrn28 import WRN28, WRN28Backbone

--- a/learn2learn/vision/models/__init__.py
+++ b/learn2learn/vision/models/__init__.py
@@ -23,5 +23,6 @@ from .cnn4 import (
     OmniglotCNN,
     MiniImagenetCNN,
     CNN4,
+    CNN4Backbone,
 )
-from .resnet12 import ResNet12
+from .resnet12 import ResNet12, ResNet12Backbone

--- a/learn2learn/vision/models/cnn4.py
+++ b/learn2learn/vision/models/cnn4.py
@@ -244,6 +244,8 @@ class CNN4(torch.nn.Module):
 
     This network assumes inputs of shapes (3, 84, 84).
 
+    Instantiate `CNN4Backbone` if you only need the feature extractor.
+
     **References**
 
     1. Ravi and Larochelle. 2017. “Optimization as a Model for Few-Shot Learning.” ICLR.

--- a/learn2learn/vision/models/cnn4.py
+++ b/learn2learn/vision/models/cnn4.py
@@ -225,6 +225,14 @@ class OmniglotCNN(torch.nn.Module):
         return x
 
 
+class CNN4Backbone(ConvBase):
+
+    def forward(self, x):
+        x = super(CNN4Backbone, self).forward(x)
+        x = x.reshape(x.size(0), -1)
+        return x
+
+
 class CNN4(torch.nn.Module):
     """
 
@@ -263,17 +271,13 @@ class CNN4(torch.nn.Module):
         super(CNN4, self).__init__()
         if embedding_size is None:
             embedding_size = 25 * hidden_size
-        base = ConvBase(
+        self.features = CNN4Backbone(
             output_size=hidden_size,
             hidden=hidden_size,
             channels=channels,
             max_pool=True,
             layers=layers,
             max_pool_factor=4 // layers,
-        )
-        self.features = torch.nn.Sequential(
-            base,
-            l2l.nn.Flatten(),
         )
         self.classifier = torch.nn.Linear(
             embedding_size,

--- a/learn2learn/vision/models/cnn4.py
+++ b/learn2learn/vision/models/cnn4.py
@@ -203,11 +203,12 @@ class OmniglotCNN(torch.nn.Module):
     def __init__(self, output_size=5, hidden_size=64, layers=4):
         super(OmniglotCNN, self).__init__()
         self.hidden_size = hidden_size
-        self.base = ConvBase(output_size=hidden_size,
-                             hidden=hidden_size,
-                             channels=1,
-                             max_pool=False,
-                             layers=layers)
+        self.base = ConvBase(
+             hidden=hidden_size,
+             channels=1,
+             max_pool=False,
+             layers=layers,
+        )
         self.features = torch.nn.Sequential(
             l2l.nn.Lambda(lambda x: x.view(-1, 1, 28, 28)),
             self.base,

--- a/learn2learn/vision/models/cnn4.py
+++ b/learn2learn/vision/models/cnn4.py
@@ -274,7 +274,6 @@ class CNN4(torch.nn.Module):
         if embedding_size is None:
             embedding_size = 25 * hidden_size
         self.features = CNN4Backbone(
-            output_size=hidden_size,
             hidden=hidden_size,
             channels=channels,
             max_pool=True,

--- a/learn2learn/vision/models/cnn4.py
+++ b/learn2learn/vision/models/cnn4.py
@@ -105,7 +105,6 @@ class ConvBase(torch.nn.Sequential):
     #     MiniImagenet: hidden=32, channels=3, max_pool
 
     def __init__(self,
-                 output_size,
                  hidden=64,
                  channels=1,
                  max_pool=False,

--- a/learn2learn/vision/models/resnet12.py
+++ b/learn2learn/vision/models/resnet12.py
@@ -195,6 +195,8 @@ class ResNet12(nn.Module):
         (640 is for mini-ImageNet; used for the classifier layer)
     * **keep_prob** (float, *optional*, default=1.0) - Dropout rate on the embedding layer.
     * **avg_pool** (bool, *optional*, default=True) - Set to False for the 16k-dim embeddings of Lee et al, 2019.
+    * **wider** (bool, *optional*, default=True) - True uses (64, 160, 320, 640) filters akin to Lee et al, 2019.
+        False uses (64, 128, 256, 512) filters, akin to Oreshkin et al, 2018.
     * **drop_rate** (float, *optional*, default=0.1) - Dropout rate for the residual layers.
     * **dropblock_size** (int, *optional*, default=5) - Size of drop blocks.
 
@@ -210,6 +212,7 @@ class ResNet12(nn.Module):
         hidden_size=640,  # mini-ImageNet images, used for the classifier
         keep_prob=1.0,  # dropout for embedding
         avg_pool=True,  # Set to False for 16000-dim embeddings
+        wider=True,  # True mimics MetaOptNet, False mimics TADAM
         drop_rate=0.1,  # dropout for residual layers
         dropblock_size=5,
     ):
@@ -217,22 +220,26 @@ class ResNet12(nn.Module):
         self.inplanes = 3
         self.output_size = output_size
         block = BasicBlock
+        if wider:
+            num_filters = [64, 160, 320, 640]
+        else:
+            num_filters = [64, 128, 256, 512]
 
         self.layer1 = self._make_layer(
             block,
-            64,
+            num_filters[0],
             stride=2,
             drop_rate=drop_rate,
         )
         self.layer2 = self._make_layer(
             block,
-            160,
+            num_filters[1],
             stride=2,
             drop_rate=drop_rate,
         )
         self.layer3 = self._make_layer(
             block,
-            320,
+            num_filters[2],
             stride=2,
             drop_rate=drop_rate,
             drop_block=True,
@@ -240,7 +247,7 @@ class ResNet12(nn.Module):
         )
         self.layer4 = self._make_layer(
             block,
-            640,
+            num_filters[3],
             stride=2,
             drop_rate=drop_rate,
             drop_block=True,

--- a/learn2learn/vision/models/resnet12.py
+++ b/learn2learn/vision/models/resnet12.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -229,8 +230,6 @@ class ResNet12Backbone(nn.Module):
             elif isinstance(m, nn.BatchNorm2d):
                 nn.init.constant_(m.weight, 1)
                 nn.init.constant_(m.bias, 0)
-        self.features = torch.nn.Sequential(
-        )
 
     def _make_layer(
         self,

--- a/learn2learn/vision/models/resnet12.py
+++ b/learn2learn/vision/models/resnet12.py
@@ -166,7 +166,6 @@ class ResNet12Backbone(nn.Module):
 
     def __init__(
         self,
-        hidden_size=640,  # mini-ImageNet images, used for the classifier
         keep_prob=1.0,  # dropout for embedding
         avg_pool=True,  # Set to False for 16000-dim embeddings
         wider=True,  # True mimics MetaOptNet, False mimics TADAM
@@ -285,6 +284,8 @@ class ResNet12(nn.Module):
     The code is adapted from [Lee et al, 2019](https://github.com/kjunelee/MetaOptNet/)
     who share it under the Apache 2 license.
 
+    Instantiate `ResNet12Backbone` if you only need the feature extractor.
+
     List of changes:
 
     * Rename ResNet to ResNet12.
@@ -330,7 +331,6 @@ class ResNet12(nn.Module):
     ):
         super(ResNet12, self).__init__()
         self.features = ResNet12Backbone(
-            hidden_size=hidden_size,
             keep_prob=keep_prob,
             avg_pool=avg_pool,
             wider=wider,

--- a/learn2learn/vision/models/resnet12.py
+++ b/learn2learn/vision/models/resnet12.py
@@ -215,9 +215,10 @@ class ResNet12(nn.Module):
         wider=True,  # True mimics MetaOptNet, False mimics TADAM
         drop_rate=0.1,  # dropout for residual layers
         dropblock_size=5,
+        channels=3,
     ):
         super(ResNet12, self).__init__()
-        self.inplanes = 3
+        self.inplanes = channels
         self.output_size = output_size
         block = BasicBlock
         if wider:

--- a/learn2learn/vision/models/wrn28.py
+++ b/learn2learn/vision/models/wrn28.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+import torch
+import torch.nn.init as init
+import torch.nn.functional as F
+
+
+def conv3x3(in_planes, out_planes, stride=1):
+    return torch.nn.Conv2d(
+        in_planes,
+        out_planes,
+        kernel_size=3,
+        stride=stride,
+        padding=1,
+        bias=True,
+    )
+
+
+def conv_init(m):
+    classname = m.__class__.__name__
+    if classname.find('Conv') != -1:
+        init.xavier_uniform(m.weight, gain=2**0.5)
+        init.constant(m.bias, 0)
+    elif classname.find('BatchNorm') != -1:
+        init.constant(m.weight, 1)
+        init.constant(m.bias, 0)
+
+
+class wide_basic(torch.nn.Module):
+
+    def __init__(self, in_planes, planes, dropout_rate, stride=1):
+        super(wide_basic, self).__init__()
+        self.bn1 = torch.nn.BatchNorm2d(in_planes)
+        self.conv1 = torch.nn.Conv2d(in_planes, planes, kernel_size=3, padding=1, bias=True)
+        self.dropout = torch.nn.Dropout(p=dropout_rate)
+        self.bn2 = torch.nn.BatchNorm2d(planes)
+        self.conv2 = torch.nn.Conv2d(planes, planes, kernel_size=3, stride=stride, padding=1, bias=True)
+
+        self.shortcut = torch.nn.Sequential()
+        if stride != 1 or in_planes != planes:
+            self.shortcut = torch.nn.Sequential(
+                torch.nn.Conv2d(
+                    in_planes,
+                    planes,
+                    kernel_size=1,
+                    stride=stride,
+                    bias=True
+                ),
+            )
+
+    def forward(self, x):
+        out = self.dropout(self.conv1(F.relu(self.bn1(x))))
+        out = self.conv2(F.relu(self.bn2(out)))
+        out += self.shortcut(x)
+        return out
+
+
+class WideResNet(torch.nn.Module):
+
+    def __init__(self, depth, widen_factor, dropout_rate):
+        super(WideResNet, self).__init__()
+        self.in_planes = 16
+
+        assert ((depth - 4) % 6 == 0), 'Wide-resnet depth should be 6n+4'
+        n = int((depth - 4) / 6)
+        k = widen_factor
+
+        nStages = [16, 16*k, 32*k, 64*k]
+
+        self.conv1 = conv3x3(3, nStages[0])
+        self.layer1 = self._wide_layer(wide_basic, nStages[1], n, dropout_rate, stride=1)
+        self.layer2 = self._wide_layer(wide_basic, nStages[2], n, dropout_rate, stride=2)
+        self.layer3 = self._wide_layer(wide_basic, nStages[3], n, dropout_rate, stride=2)
+        self.bn1 = torch.nn.BatchNorm2d(nStages[3], momentum=0.9)
+
+    def _wide_layer(self, block, planes, num_blocks, dropout_rate, stride):
+        strides = [stride] + [1]*(num_blocks-1)
+        layers = []
+
+        for stride in strides:
+            layers.append(block(self.in_planes, planes, dropout_rate, stride))
+            self.in_planes = planes
+
+        return torch.nn.Sequential(*layers)
+
+    def forward(self, x):
+        out = self.conv1(x)
+        out = self.layer1(out)
+        out = self.layer2(out)
+        out = self.layer3(out)
+        out = F.relu(self.bn1(out))
+        out = F.avg_pool2d(out, 21)
+        out = out.view(out.size(0), -1)
+        return out
+
+
+class WRN28Backbone(WideResNet):
+
+    def __init__(self, dropout=0.0):
+        super(WRN28Backbone, self).__init__(
+            depth=28,
+            widen_factor=10,
+            dropout_rate=dropout,
+        )
+
+
+class WRN28(torch.nn.Module):
+
+    """
+    pass
+    """
+
+    def __init__(
+        self,
+        output_size,
+        hidden_size=640,  # default for mini-ImageNet
+        dropout=0.0,
+    ):
+        super(WRN28, self).__init__()
+        self.features = WRN28Backbone(dropout=dropout)
+        self.classifier = torch.nn.Linear(hidden_size, output_size)
+
+    def forward(self, x):
+        x = self.features(x)
+        x = self.classifier(x)
+        return x
+
+
+if __name__ == "__main__":
+    wrn = WRN28(output_size=5)
+    img = torch.randn(5, 3, 84, 84)
+    out = wrn(img)
+    wrnbb = WRN28Backbone()
+    out = wrnbb(img)

--- a/learn2learn/vision/models/wrn28.py
+++ b/learn2learn/vision/models/wrn28.py
@@ -107,7 +107,34 @@ class WRN28Backbone(WideResNet):
 class WRN28(torch.nn.Module):
 
     """
-    pass
+    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/vision/models/wrn28.py)
+
+    **Description**
+
+    The 28-layer 10-depth wide residual network from Dhillon et al, 2020.
+
+    The code is adapted from [Ye et al, 2020](https://github.com/Sha-Lab/FEAT)
+    who share it under the MIT license.
+
+    Instantiate `WRN28Backbone` if you only need the feature extractor.
+
+    **References**
+
+    1. Dhillon et al. 2020. “A Baseline for Few-Shot Image Classification.” ICLR 20.
+    2. Ye et al. 2020. “Few-Shot Learning via Embedding Adaptation with Set-to-Set Functions.” CVPR 20.
+    3. Ye et al's code: [https://github.com/Sha-Lab/FEAT](https://github.com/Sha-Lab/FEAT)
+
+    **Arguments**
+
+    * **output_size** (int) - The dimensionality of the output.
+    * **hidden_size** (list, *optional*, default=640) - Size of the embedding once features are extracted.
+        (640 is for mini-ImageNet; used for the classifier layer)
+    * **dropout** (float, *optional*, default=0.0) - Dropout rate.
+
+    **Example**
+    ~~~python
+    model = WRN28(output_size=ways, hidden_size=1600, avg_pool=False)
+    ~~~
     """
 
     def __init__(

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,6 @@ install(
         'gsutil',
         'tqdm',
         'qpth>=0.0.15',
-        'pytorch_lightning>=1.0.2',
+        #  'pytorch_lightning>=1.0.2',
     ],
 )

--- a/tests/unit/data/metadataset_test.py
+++ b/tests/unit/data/metadataset_test.py
@@ -18,7 +18,6 @@ class TestMetaDataset(TestCase):
         cls.meta_tensor_dataset = MetaDataset(cls.ds.tensor_dataset)
         cls.meta_str_dataset = MetaDataset(cls.ds.str_dataset)
         cls.meta_alpha_dataset = MetaDataset(cls.ds.alphabet_dataset)
-        cls.mnist_dataset = MetaDataset(cls.ds.get_mnist())
         cls.omniglot_dataset = MetaDataset(cls.ds.get_omniglot())
 
     def test_fails_with_non_torch_dataset(self):
@@ -34,14 +33,12 @@ class TestMetaDataset(TestCase):
         self.assertEqual(len(self.meta_tensor_dataset), self.ds.n)
         self.assertEqual(len(self.meta_str_dataset), self.ds.n)
         self.assertEqual(len(self.meta_alpha_dataset), 26)
-        self.assertEqual(len(self.mnist_dataset), 60000)
         self.assertEqual(len(self.omniglot_dataset), 32460)
 
     def test_data_labels_length(self):
         self.assertEqual(len(self.meta_tensor_dataset.labels), len(self.ds.tensor_classes))
         self.assertEqual(len(self.meta_str_dataset.labels), len(self.ds.str_classes))
         self.assertEqual(len(self.meta_alpha_dataset.labels), 26)
-        self.assertEqual(len(self.mnist_dataset.labels), len(self.ds.mnist_classes))
         self.assertEqual(len(self.omniglot_dataset.labels), len(self.ds.omniglot_classes))
 
     def test_data_labels_values(self):


### PR DESCRIPTION
### Description

* Adds an option to get the ResNet12 from TADAM, and WRN28 from Dhillon et al. 
* Adds `l2l.vision.models.get_pretrained_backbone` and backbone modules for CNN4, ResNet12, WRN28 (pretrained backbones from FEAT).

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [x] My modifications are documented.
