### PR TITLE
Adding maxpool to match paper results

### DIFF
--- a/examples/vision/protonet_miniimagenet.py
+++ b/examples/vision/protonet_miniimagenet.py
@@ -31,7 +31,8 @@ class Convnet(nn.Module):
         super().__init__()
         self.encoder = l2l.vision.models.ConvBase(output_size=z_dim,
                                                   hidden=hid_dim,
-                                                  channels=x_dim)
+                                                  channels=x_dim,
+                                                  max_pool=True)
         self.out_channels = 1600
 
     def forward(self, x):


### PR DESCRIPTION
### Description

Fixes #219 https://github.com/learnables/learn2learn/issues/219

Results of protonet_miniimagenet.py not matching reported results. (43 vs 49 )

Passing max_pool=True to convbase in the convnet of protonet_miniimagenet.py
