### PR TITLE
Fix the link to Lightning module for Model-Agnostic Meta-Learning in docs

### DIFF
--- a/learn2learn/algorithms/lightning/lightning_maml.py
+++ b/learn2learn/algorithms/lightning/lightning_maml.py
@@ -10,7 +10,7 @@ from learn2learn.algorithms.lightning import LightningEpisodicModule
 
 class LightningMAML(LightningEpisodicModule):
     """
-    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/algorithms/lightning_maml.py)
+    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/algorithms/lightning/lightning_maml.py)
 
     **Description**
 


### PR DESCRIPTION
- [x] My contribution modifies code in the main library.

Fixes the link to MAML Lightning `[Source]` in http://learn2learn.net/docs/learn2learn.algorithms/