### PR TITLE
Fix the link to Lightning module for Prototypical Networks in docs

### DIFF
--- a/learn2learn/algorithms/lightning/lightning_protonet.py
+++ b/learn2learn/algorithms/lightning/lightning_protonet.py
@@ -13,7 +13,7 @@ from learn2learn.algorithms.lightning import LightningEpisodicModule
 
 class LightningPrototypicalNetworks(LightningEpisodicModule):
     """
-    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/algorithms/lightning_prototypicalnets.py)
+    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/algorithms/lightning/lightning_protonet.py)
 
     **Description**
 


### PR DESCRIPTION
- [x] My contribution modifies code in the main library.

Fixes the link to ProtoNets Lightning `[Source]` in http://learn2learn.net/docs/learn2learn.algorithms/
