### PR TITLE
Fix the link to Lightning module for MetaOptNet (Meta-Learning with Differentiable Convex Optimization) in docs

### DIFF
--- a/learn2learn/algorithms/lightning/lightning_metaoptnet.py
+++ b/learn2learn/algorithms/lightning/lightning_metaoptnet.py
@@ -13,7 +13,7 @@ from learn2learn.algorithms.lightning import (
 
 class LightningMetaOptNet(LightningPrototypicalNetworks):
     """
-    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/algorithms/lightning_metaoptnet.py)
+    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/algorithms/lightning/lightning_metaoptnet.py)
 
     **Description**
 


### PR DESCRIPTION
- [x] My contribution modifies code in the main library.

Fixes the link to MetaOptNet (Meta-Learning with Differentiable Convex Optimization) Lightning [Source] in http://learn2learn.net/docs/learn2learn.algorithms/
