### PR TITLE
Fix logging in PL 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fix arguments when instantiating `l2l.nn.Scale`.
+* Fix `train_loss` logging in `LightningModule` implementations with PyTorch-Lightning 1.5.
 
 
 ## v0.1.6

--- a/learn2learn/algorithms/lightning/lightning_episodic_module.py
+++ b/learn2learn/algorithms/lightning/lightning_episodic_module.py
@@ -77,7 +77,7 @@ class LightningEpisodicModule(LightningModule):
             "train_loss",
             train_loss.item(),
             on_step=False,
-            on_epoch=False,
+            on_epoch=True,
             prog_bar=False,
             logger=True,
         )


### PR DESCRIPTION
### Description

Logging with `on_step = on_epoch = False` raises an error in PL 1.5 or greater.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution is listed in CHANGELOG.md with attribution.
- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [ ] My modifications are documented.

#### Optional

If you make major changes to the core library, please run `make alltests` and copy-paste the content of `alltests.txt` below.

~~~shell
[PASTE HERE]
~~~
