### PR TITLE
added the rfs transforms for cifarfs (and fc100)

### DIFF
--- a/learn2learn/vision/benchmarks/cifarfs_benchmark.py
+++ b/learn2learn/vision/benchmarks/cifarfs_benchmark.py
@@ -12,11 +12,58 @@ def cifarfs_tasksets(
     test_ways=5,
     test_samples=10,
     root='~/data',
+    data_augmentation=None,
     device=None,
     **kwargs,
 ):
     """Tasksets for CIFAR-FS benchmarks."""
-    data_transform = tv.transforms.ToTensor()
+    if data_augmentation is None:
+        train_data_transforms = tv.transforms.ToTensor()
+        test_data_transforms = tv.transforms.ToTensor()
+    elif data_augmentation == 'normalize':
+        train_data_transforms = Compose([
+            lambda x: x / 255.0,
+        ])
+        test_data_transforms = train_data_transforms
+    elif data_augmentation == 'rfs2020':
+        """
+        # original
+    if augment:
+        transform = transforms.Compose([
+            lambda x: Image.fromarray(x),
+            transforms.RandomCrop(32, padding=4),
+            transforms.ColorJitter(brightness=0.4, contrast=0.4, saturation=0.4),
+            transforms.RandomHorizontalFlip(),
+            lambda x: np.asarray(x),
+            transforms.ToTensor(),
+            normalize_cifar100
+        ])
+    else:
+        transform = transforms.Compose([
+            lambda x: Image.fromarray(x),
+            transforms.ToTensor(),
+            normalize_cifar100
+        ])
+    return transform
+    """
+        mean = [0.5071, 0.4867, 0.4408]
+        std = [0.2675, 0.2565, 0.2761]
+        normalize = tv.transforms.Normalize(mean=mean, std=std)
+        train_data_transforms = Compose([
+            ToPILImage(),
+            RandomCrop(32, padding=4),
+            ColorJitter(brightness=0.4, contrast=0.4, saturation=0.4),
+            RandomHorizontalFlip(),
+            ToTensor(),
+            normalize,
+        ])
+        test_data_transforms = Compose([
+            ToTensor(),
+            normalize,
+        ])
+    else:
+        raise('Invalid data_augmentation argument.')
+        
     train_dataset = l2l.vision.datasets.CIFARFS(root=root,
                                                 transform=data_transform,
                                                 mode='train',


### PR DESCRIPTION
added the rfs transforms for cifarfs (and fc100)

### Description

[Fixes #[ISSUE NUMBER]](https://github.com/learnables/learn2learn/issues/302)

Added the data transform according to rfs paper for cifarfs, fc100 original rfs code: https://github.com/WangYueFt/rfs/blob/f8c837ba93c62dd0ac68a2f4019c619aa86b8421/dataset/cifar.py#L26

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [ ] My contribution is listed in CHANGELOG.md with attribution.
- [x] My contribution modifies code in the main library.
- [ ] My modifications are tested.
- [ ] My modifications are documented.
