### PR TITLE
[FIX] example for detach_module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+* example for `detach_module`. ([Nimish Sanghi](https://github.com/nsanghi))
 
 ## v0.1.7
 

--- a/learn2learn/utils/__init__.py
+++ b/learn2learn/utils/__init__.py
@@ -171,9 +171,9 @@ def detach_module(module, keep_requires_grad=False):
     **Example**
 
     ~~~python
-    net = nn.Sequential(Linear(20, 10), nn.ReLU(), nn.Linear(10, 2))
+    net = nn.Sequential(nn.Linear(20, 10), nn.ReLU(), nn.Linear(10, 2))
     clone = clone_module(net)
-    detach_module(clone)
+    detach_module(clone, keep_requires_grad=True)
     error = loss(clone(X), y)
     error.backward()  # Gradients are back-propagate on clone, not net.
     ~~~


### PR DESCRIPTION
### Description
It fixes example given in the function definition of `detach_module`

Fixes #[308](https://github.com/learnables/learn2learn/issues/308)

The example shown for `detach_module` . The example correctly shows the way to clone and detach for gradient to flow through the parameters of the clone and not the main network.


If necessary, use the following space to provide context or more details.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution is listed in CHANGELOG.md with attribution.
- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [x] My modifications are documented.
