### PR TITLE
Wrong name for an argument in a class instantiation

### DIFF
--- a/examples/vision/anilkfo_cifarfs.py
+++ b/examples/vision/anilkfo_cifarfs.py
@@ -28,7 +28,6 @@ class CifarCNN(torch.nn.Module):
         super(CifarCNN, self).__init__()
         self.hidden_size = hidden_size
         features = l2l.vision.models.ConvBase(
-            output_size=hidden_size,
             hidden=hidden_size,
             channels=3,
             max_pool=False,

--- a/examples/vision/metacurvature_fc100.py
+++ b/examples/vision/metacurvature_fc100.py
@@ -28,7 +28,6 @@ class CifarCNN(torch.nn.Module):
         super(CifarCNN, self).__init__()
         self.hidden_size = hidden_size
         features = l2l.vision.models.ConvBase(
-            output_size=hidden_size,
             hidden=hidden_size,
             channels=3,
             max_pool=False,

--- a/examples/vision/protonet_miniimagenet.py
+++ b/examples/vision/protonet_miniimagenet.py
@@ -100,11 +100,11 @@ if __name__ == '__main__':
 
     path_data = '~/data'
     train_dataset = l2l.vision.datasets.MiniImagenet(
-        root=path_data, mode='train')
+        root=path_data, mode='train', download=True)
     valid_dataset = l2l.vision.datasets.MiniImagenet(
-        root=path_data, mode='validation')
+        root=path_data, mode='validation', download=True)
     test_dataset = l2l.vision.datasets.MiniImagenet(
-        root=path_data, mode='test')
+        root=path_data, mode='test', download=True)
 
     train_dataset = l2l.data.MetaDataset(train_dataset)
     train_transforms = [

--- a/examples/vision/protonet_miniimagenet.py
+++ b/examples/vision/protonet_miniimagenet.py
@@ -30,7 +30,7 @@ class Convnet(nn.Module):
     def __init__(self, x_dim=3, hid_dim=64, z_dim=64):
         super().__init__()
         self.encoder = l2l.vision.models.CNN4Backbone(
-            hidden=hid_dim,
+            hidden_size=hid_dim,
             channels=x_dim,
             max_pool=True,
        )


### PR DESCRIPTION
### Description

Using a named argument whose name does not correspond to a parameter of the __init__ method of the class being instantiated, resulted in a TypeError at runtime.

Fixed the arguments in 3 example files.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [ ] My contribution is listed in CHANGELOG.md with attribution.
- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [ ] My modifications are documented.
