### PR TITLE
Fix maml_toy example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* New vision example: MAML++. (@[DubiousCactus](https://github.com/DubiousCactus))
+* New vision example: MAML++. (@[Theo Morales](https://github.com/DubiousCactus))
 * Add tutorial: "Demystifying Task Transforms", ([Varad Pimpalkhute](https://github.com/nightlessbaron/))
 
 ### Changed
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* MAML Toy example. (@[Theo Morales](https://github.com/DubiousCactus))
 * Example for `detach_module`. ([Nimish Sanghi](https://github.com/nsanghi))
 * Loading duplicate FGVC Aircraft images.
 

--- a/examples/maml_toy.py
+++ b/examples/maml_toy.py
@@ -22,7 +22,7 @@ class Model(nn.Module):
     def __init__(self):
         super(Model, self).__init__()
         self.mu = nn.Parameter(th.randn(DIM))
-        self.sigma = nn.Parameter(th.randn(DIM))
+        self.sigma = nn.Parameter(th.abs(th.randn(DIM)))
 
     def forward(self, x=None):
         return dist.Normal(self.mu, self.sigma)


### PR DESCRIPTION
### Description

The MAML Toy example `examples/maml_toy.py` does not run due to a sigma parameter being sampled from a Normal distribution. That sigma is used to parameterise another Normal distribution, hence must be positive.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution is listed in CHANGELOG.md with attribution.
- [ ] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [ ] My modifications are documented.
