### PR TITLE
Implement BatchNorm with BNRS in the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* New vision example: MAML++. (@[DubiousCactus](https://github.com/DubiousCactus))
+* New BatchNorm layer with per-step running statistics and weights & biases from MAML++. (@[Théo Morales](https://github.com/DubiousCactus))
+* New vision example: MAML++. (@[Théo Morales](https://github.com/DubiousCactus))
 * Add tutorial: "Demystifying Task Transforms", ([Varad Pimpalkhute](https://github.com/nightlessbaron/))
 
 ### Changed

--- a/examples/vision/mamlpp/maml++_miniimagenet.py
+++ b/examples/vision/mamlpp/maml++_miniimagenet.py
@@ -20,7 +20,7 @@ from collections import namedtuple
 from typing import Tuple
 from tqdm import tqdm
 
-from examples.vision.mamlpp.cnn4_bnrs import CNN4_BNRS
+from learn2learn.vision.models.cnn4_bnrs import CNN4_BNRS
 from examples.vision.mamlpp.MAMLpp import MAMLpp
 
 

--- a/learn2learn/vision/models/__init__.py
+++ b/learn2learn/vision/models/__init__.py
@@ -31,8 +31,17 @@ from .cnn4 import (
     CNN4Backbone,
 )
 
+from .cnn4_bnrs import (
+    LinearBlock_BNRS,
+    ConvBlock_BNRS,
+    ConvBase_BNRS,
+    CNN4Backbone_BNRS,
+    CNN4_BNRS,
+)
+
 from .resnet12 import ResNet12, ResNet12Backbone
 from .wrn28 import WRN28, WRN28Backbone
+from .bnrs import BatchNorm_BNRS
 
 __all__ = [
     'get_pretrained_backbone',
@@ -49,6 +58,12 @@ __all__ = [
     'ResNet12Backbone',
     'WRN28',
     'WRN28Backbone',
+    'BatchNorm_BNRS',
+    'LinearBlock_BNRS',
+    'ConvBlock_BNRS',
+    'ConvBase_BNRS',
+    'CNN4Backbone_BNRS',
+    'CNN4_BNRS',
 ]
 
 _BACKBONE_URLS = {

--- a/learn2learn/vision/models/bnrs.py
+++ b/learn2learn/vision/models/bnrs.py
@@ -1,0 +1,104 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+
+"""
+BatchNorm layer augmented with Per-Step Batch Normalisation Running Statistics and Per-Step Batch
+Normalisation Weights and Biases, as proposed in MAML++ by Antobiou et al.
+"""
+
+import torch
+import torch.nn.functional as F
+
+from copy import deepcopy
+from learn2learn.vision.models.cnn4 import maml_init_, fc_init_
+
+
+class BatchNorm_BNRS(torch.nn.Module):
+    """
+    An extension of Pytorch's BatchNorm layer, with the Per-Step Batch Normalisation Running
+    Statistics and Per-Step Batch Normalisation Weights and Biases improvements proposed in
+    MAML++ by Antoniou et al. It is adapted from the original Pytorch implementation at
+    https://github.com/AntreasAntoniou/HowToTrainYourMAMLPytorch,
+    with heavy refactoring and a bug fix
+    (https://github.com/AntreasAntoniou/HowToTrainYourMAMLPytorch/issues/42).
+    """
+
+    def __init__(
+        self,
+        num_features,
+        eps=1e-5,
+        momentum=0.1,
+        affine=True,
+        meta_batch_norm=True,
+        adaptation_steps: int = 1,
+    ):
+        super(BatchNorm_BNRS, self).__init__()
+        self.num_features = num_features
+        self.eps = eps
+        self.affine = affine
+        self.meta_batch_norm = meta_batch_norm
+        self.num_features = num_features
+        self.running_mean = torch.nn.Parameter(
+            torch.zeros(adaptation_steps, num_features), requires_grad=False
+        )
+        self.running_var = torch.nn.Parameter(
+            torch.ones(adaptation_steps, num_features), requires_grad=False
+        )
+        self.bias = torch.nn.Parameter(
+            torch.zeros(adaptation_steps, num_features), requires_grad=True
+        )
+        self.weight = torch.nn.Parameter(
+            torch.ones(adaptation_steps, num_features), requires_grad=True
+        )
+        self.backup_running_mean = torch.zeros(self.running_mean.shape)
+        self.backup_running_var = torch.ones(self.running_var.shape)
+        self.momentum = momentum
+
+    def forward(
+        self,
+        input,
+        step,
+    ):
+        """
+        :param input: input data batch, size either can be any.
+        :param step: The current inner loop step being taken. This is used when to learn per step params and
+         collecting per step batch statistics.
+        :return: The result of the batch norm operation.
+        """
+        assert (
+            step < self.running_mean.shape[0]
+        ), f"Running forward with step={step} when initialised with {self.running_mean.shape[0]} steps!"
+        return F.batch_norm(
+            input,
+            self.running_mean[step],
+            self.running_var[step],
+            self.weight[step],
+            self.bias[step],
+            training=True,
+            momentum=self.momentum,
+            eps=self.eps,
+        )
+
+    def backup_stats(self):
+        self.backup_running_mean.data = deepcopy(self.running_mean.data)
+        self.backup_running_var.data = deepcopy(self.running_var.data)
+
+    def restore_backup_stats(self):
+        """
+        Resets batch statistics to their backup values which are collected after each forward pass.
+        """
+        self.running_mean = torch.nn.Parameter(
+            self.backup_running_mean, requires_grad=False
+        )
+        self.running_var = torch.nn.Parameter(
+            self.backup_running_var, requires_grad=False
+        )
+
+    def extra_repr(self):
+        return "{num_features}, eps={eps}, momentum={momentum}, affine={affine}".format(
+            **self.__dict__
+        )
+
+


### PR DESCRIPTION
### Description

Implementation of a BatchNorm layer with Per-Step Batch Normalisation Running Statistics and Per-Step Batch Normalisation Weights and Biases, as proposed in MAML++ by Antobiou et al.

An extension of Pytorch's BatchNorm layer, with the Per-Step Batch Normalisation Running Statistics and Per-Step Batch Normalisation Weights and Biases improvements proposed MAML++ by Antoniou et al. It is adapted from the original Pytorch implementation https://github.com/AntreasAntoniou/with heavy refactoring and a bug (https://github.com/AntreasAntoniou/HowToTrainYourMAMLPytorch/issues/42).

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution is listed in CHANGELOG.md with attribution.
- [x] My contribution modifies code in the main library.
- [ ] My modifications are tested.
- [x] My modifications are documented.