### PR TITLE
Meta-learning rate in reptile example is not decaying (as of now).

### DIFF
--- a/examples/vision/reptile_miniimagenet.py
+++ b/examples/vision/reptile_miniimagenet.py
@@ -52,6 +52,7 @@ def main(
         train_shots=15,
         test_shots=5,
         meta_lr=1.0,
+        meta_lr_final=1.0,
         meta_bsz=5,
         fast_lr=0.001,
         train_bsz=10,
@@ -108,7 +109,7 @@ def main(
 
         # anneal meta-lr
         frac_done = float(iteration) / iterations
-        new_lr = frac_done * meta_lr + (1 - frac_done) * meta_lr
+        new_lr = frac_done * meta_lr_final + (1 - frac_done) * meta_lr
         for pg in opt.param_groups:
             pg['lr'] = new_lr
 


### PR DESCRIPTION
Added meta_lr_final parameter to indicate the final value of the meta learning rate. By setting meta_lr_final to a smaller value than meta_lr, the meta learning rate is effectively decayed during training. Before it was constant due to the bug of using meta_lr both times in the weighted sum. 

### Description

Fixes #[ISSUE NUMBER]

Replace this line by a one sentence summary of your PR.

If necessary, use the following space to provide context or more details.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [ ] My contribution is listed in CHANGELOG.md with attribution.
- [x] My contribution modifies code in the main library.
- [ ] My modifications are tested.
- [ ] My modifications are documented.

#### Optional

If you make major changes to the core library, please run `make alltests` and copy-paste the content of `alltests.txt` below.

~~~shell
[PASTE HERE]
~~~
