### PR TITLE
fix inheritance in NoLeaveProgressBar

### DIFF
--- a/learn2learn/utils/lightning.py
+++ b/learn2learn/utils/lightning.py
@@ -67,7 +67,7 @@ class EpisodicBatcher(pl.LightningDataModule):
         )
 
 
-class NoLeaveProgressBar(pl.callbacks.ProgressBar):
+class NoLeaveProgressBar(pl.callbacks.TQDMProgressBar):
 
     def init_test_tqdm(self):
         bar = tqdm.tqdm(


### PR DESCRIPTION
### Description

Fixes #346

pytorch lightning doesn't include `pl.callbacks.ProgressBar` anymore, so I replaecd it with `TQDMProgressBar` to fix import error
### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [ ] My contribution is listed in CHANGELOG.md with attribution.
- [x] My contribution modifies code in the main library.
- [ ] My modifications are tested.
- [ ] My modifications are documented.

