### PR TITLE
Fix MetaEnv initialization.

### DIFF
--- a/learn2learn/gym/envs/meta_env.py
+++ b/learn2learn/gym/envs/meta_env.py
@@ -30,7 +30,7 @@ class MetaEnv(Env):
     """
 
     def __init__(self, task=None):
-        super(MetaEnv, self).__init__()
+        Env.__init__(self)
         if task is None:
             task = self.sample_tasks(1)[0]
         self.set_task(task)


### PR DESCRIPTION
### Description

Fixes #411

In meta_env.py. `super(MetaEnv, self).__init__()` is changed to `Env.__init__(self)`.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [ ] My contribution is listed in CHANGELOG.md with attribution.
- [x] My contribution modifies code in the main library.
- [ ] My modifications are tested.
- [ ] My modifications are documented.

