### PR TITLE
Update incorrect URLs in `utils/__init__.py`

### DIFF
--- a/learn2learn/utils/__init__.py
+++ b/learn2learn/utils/__init__.py
@@ -10,7 +10,7 @@ import warnings
 def magic_box(x):
     """
 
-    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/utils.py)
+    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/utils/__init__.py)
 
     **Description**
 
@@ -58,7 +58,7 @@ def clone_named_parameters(param_dict):
 def clone_module(module, memo=None):
     """
 
-    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/utils.py)
+    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/utils/__init__.py)
 
     **Description**
 
@@ -158,7 +158,7 @@ def clone_module(module, memo=None):
 def detach_module(module, keep_requires_grad=False):
     """
 
-    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/utils.py)
+    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/utils/__init__.py)
 
     **Description**
 
@@ -239,7 +239,7 @@ def detach_distribution(dist):
 
 def update_module(module, updates=None, memo=None):
     r"""
-    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/utils.py)
+    [[Source]](https://github.com/learnables/learn2learn/blob/master/learn2learn/utils/__init__.py)
 
     **Description**
 


### PR DESCRIPTION


### Description

There are incorrect Source urls on several functions defined in `utils`. They are linking to a `utils.py` file, which was turned into a subpackage, so now they are located in `utils/__init__.py`.

The only changes are in docstrings.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [ ] My contribution is listed in CHANGELOG.md with attribution.
- [ ] My contribution modifies code in the main library.
- [ ] My modifications are tested.
- [ ] My modifications are documented.

#### Optional

If you make major changes to the core library, please run `make alltests` and copy-paste the content of `alltests.txt` below.

~~~shell
[PASTE HERE]
~~~
